### PR TITLE
Added the option to change the name of the identification attribute

### DIFF
--- a/app/authenticators/token.js
+++ b/app/authenticators/token.js
@@ -117,9 +117,12 @@ export default Base.extend({
     @return {object} An object with properties for authentication.
   */
   getAuthenticateData: function(credentials) {
-    var authentication = {};
-    authentication['password'] = credentials.password;
+    var authentication = {
+      password: credentials.password
+    };
+
     authentication[this.identificationField] = credentials.identification
+
     return authentication;
   },
 

--- a/app/authenticators/token.js
+++ b/app/authenticators/token.js
@@ -34,12 +34,32 @@ export default Base.extend({
   serverTokenEndpoint: '/api-token-auth/',
 
   /**
+    The attribute-name that is used for the identification field when sending the 
+    authentication data to the server.
+
+    This value can be configured via the global environment object:
+
+    ```js
+    window.ENV = window.ENV || {};
+    window.ENV['simple-auth-token'] = {
+      identificationField: 'email'
+    }
+    ```
+
+    @property identificationField
+    @type String
+    @default 'username'
+  */
+  identificationField: 'username',
+
+  /**
     @method init
     @private
   */
   init: function() {
     var globalConfig = getGlobalConfig('simple-auth-token');
     this.serverTokenEndpoint = globalConfig.serverTokenEndpoint || this.serverTokenEndpoint;
+    this.identificationField = globalConfig.identificationField || this.identificationField;
   },
 
   /**
@@ -97,10 +117,10 @@ export default Base.extend({
     @return {object} An object with properties for authentication.
   */
   getAuthenticateData: function(credentials) {
-    return {
-      username: credentials.identification,
-      password: credentials.password
-    };
+    var authentication = {};
+    authentication['password'] = credentials.password;
+    authentication[this.identificationField] = credentials.identification
+    return authentication;
   },
 
   /**

--- a/app/authenticators/token.js
+++ b/app/authenticators/token.js
@@ -34,7 +34,7 @@ export default Base.extend({
   serverTokenEndpoint: '/api-token-auth/',
 
   /**
-    The attribute-name that is used for the identification field when sending the 
+    The attribute-name that is used for the identification field when sending the
     authentication data to the server.
 
     This value can be configured via the global environment object:
@@ -121,7 +121,7 @@ export default Base.extend({
       password: credentials.password
     };
 
-    authentication[this.identificationField] = credentials.identification
+    authentication[this.identificationField] = credentials.identification;
 
     return authentication;
   },


### PR DESCRIPTION
Our backend requires the identification attribute to be `email` rather than username, so I added the option to change that.
Let me know if all is looking good.
