### PR TITLE
Extracts the method that builds the token

### DIFF
--- a/app/authorizers/token.js
+++ b/app/authorizers/token.js
@@ -97,7 +97,7 @@ export default Base.extend({
     @param {Object} requestOptions The options as provided to the `$.ajax` method (see http://api.jquery.com/jQuery.ajaxPrefilter/)
   */
   authorize: function(jqXHR, requestOptions) {
-    var token = this.get('session.' + this.tokenPropertyName);
+    var token = this.buildToken();
 
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(token)) {
       if (!isSecureUrl(requestOptions.url)) {
@@ -110,5 +110,15 @@ export default Base.extend({
 
       jqXHR.setRequestHeader(this.authorizationHeaderName, token);
     }
+  },
+
+  /**
+    Builds the token string. It can be overriden for inclusion of quotes.
+
+    @method buildToken
+    @return {String}
+  */
+  buildToken: function() {
+    return this.get('session.' + this.tokenPropertyName);
   }
 });


### PR DESCRIPTION
I need to have quotes around my token (e.g `Token token="myusertoken"`). I feel it's inconvenient to have to rewrite the entire `authorize` method just for that.

On a side note, I think someone should try to come up with the basic structure for tests. There are no tests for this repo.
