### PR TITLE
added enableHttpsWarnings configuration property

### DIFF
--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -153,7 +153,7 @@ export default Base.extend({
     @private
   */
   makeRequest: function(data) {
-    if (!isSecureUrl(this.serverTokenEndpoint)) {
+    if (!isSecureUrl(this.serverTokenEndpoint) && Configuration.enableHttpsWarnings) {
       Ember.Logger.warn('Credentials are transmitted via an insecure connection - use HTTPS to keep them secure.');
     }
     return Ember.$.ajax({

--- a/addon/authorizers/token.js
+++ b/addon/authorizers/token.js
@@ -81,7 +81,7 @@ export default Base.extend({
     var token = this.buildToken();
 
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(token)) {
-      if (!isSecureUrl(requestOptions.url)) {
+      if (!isSecureUrl(requestOptions.url) && Configuration.enableHttpsWarnings) {
         Ember.Logger.warn('Credentials are transmitted via an insecure connection - use HTTPS to keep them secure.');
       }
 

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -6,6 +6,7 @@ var defaults = {
   tokenPropertyName: 'token',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
+  enableHttpsWarnings: false
 };
 
 /**
@@ -83,6 +84,17 @@ export default {
     @default 'Authorization'
   */
   authorizationHeaderName: defaults.authorizationHeaderName,
+
+  /**
+    Enables https warnings in console
+
+    @property enableHttpsWarnings
+    @readOnly
+    @static
+    @type Boolean
+    @default 'false'
+  */
+  enableHttpsWarnings: defaults.enableHttpsWarnings,
 
   /**
     @method load

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -33,3 +33,7 @@ test('authorizationPrefix', function() {
 test('authorizationHeaderName', function() {
   equal(Configuration.authorizationHeaderName, 'Authorization', 'defaults to "Authorization"');
 });
+
+test('enableHttpsWarnings', function() {
+  equal(Configuration.enableHttpsWarnings, false, 'defaults to "false"');
+});


### PR DESCRIPTION
While local development it would be nice, that you can disable https warnings.

That's why I added a configuration property called "enableHttpsWarnings" which defaults to false
