### PR TITLE
Add support for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,6 @@ ENV['simple-auth-token'] = {
   tokenPropertyName: 'token',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
+  customHeaders: {}
 };
 ```

--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -52,6 +52,18 @@ export default Base.extend({
   tokenPropertyName: 'token',
 
   /**
+    The property that stores custom headers that will be sent on every request.
+
+    This value can be configured via
+    [`SimpleAuth.Configuration.Token#customHeaders`](#SimpleAuth-Configuration-Token-customHeaders).
+
+    @property customHeaders
+    @type Object
+    @default {}
+  */
+  customHeaders: {},
+
+  /**
     @method init
     @private
   */
@@ -59,6 +71,7 @@ export default Base.extend({
     this.serverTokenEndpoint = Configuration.serverTokenEndpoint;
     this.identificationField = Configuration.identificationField;
     this.tokenPropertyName = Configuration.tokenPropertyName;
+    this.customHeaders = Configuration.customHeaders;
   },
 
   /**
@@ -160,7 +173,8 @@ export default Base.extend({
       contentType: 'application/json',
       beforeSend: function(xhr, settings) {
         xhr.setRequestHeader('Accept', settings.accepts.json);
-      }
+      },
+      headers: this.customHeaders
     });
   }
 });

--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -55,13 +55,13 @@ export default Base.extend({
     The property that stores custom headers that will be sent on every request.
 
     This value can be configured via
-    [`SimpleAuth.Configuration.Token#customHeaders`](#SimpleAuth-Configuration-Token-customHeaders).
+    [`SimpleAuth.Configuration.Token#headers`](#SimpleAuth-Configuration-Token-headers).
 
-    @property customHeaders
+    @property headers
     @type Object
     @default {}
   */
-  customHeaders: {},
+  headers: {},
 
   /**
     @method init
@@ -71,7 +71,7 @@ export default Base.extend({
     this.serverTokenEndpoint = Configuration.serverTokenEndpoint;
     this.identificationField = Configuration.identificationField;
     this.tokenPropertyName = Configuration.tokenPropertyName;
-    this.customHeaders = Configuration.customHeaders;
+    this.headers = Configuration.headers;
   },
 
   /**
@@ -174,7 +174,7 @@ export default Base.extend({
       beforeSend: function(xhr, settings) {
         xhr.setRequestHeader('Accept', settings.accepts.json);
       },
-      headers: this.customHeaders
+      headers: this.headers
     });
   }
 });

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -6,6 +6,7 @@ var defaults = {
   tokenPropertyName: 'token',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
+  customHeaders: {}
 };
 
 /**
@@ -83,6 +84,17 @@ export default {
     @default 'Authorization'
   */
   authorizationHeaderName: defaults.authorizationHeaderName,
+
+  /**
+    Custom headers to be added on request.
+
+    @property customHeaders
+    @readonly
+    @static
+    @type Object
+    @default {}
+  */
+  customHeaders: defaults.customHeaders,
 
   /**
     @method load

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -6,7 +6,7 @@ var defaults = {
   tokenPropertyName: 'token',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
-  customHeaders: {}
+  headers: {}
 };
 
 /**
@@ -88,13 +88,13 @@ export default {
   /**
     Custom headers to be added on request.
 
-    @property customHeaders
+    @property headers
     @readonly
     @static
     @type Object
     @default {}
   */
-  customHeaders: defaults.customHeaders,
+  headers: defaults.headers,
 
   /**
     @method load

--- a/tests/unit/authenticators/token-test.js
+++ b/tests/unit/authenticators/token-test.js
@@ -44,6 +44,14 @@ test('assigns tokenPropertyName from the configuration object', function() {
   Configuration.load({}, {});
 });
 
+test('assigns customHeaders from the configuration object', function() {
+  Configuration.customHeaders = 'customHeaders';
+
+  equal(Token.create().customHeaders, 'customHeaders');
+
+  Configuration.load({}, {});
+});
+
 test('#restore resolves with the correct data', function() {
   var properties = {
     token: 'secret token!'
@@ -83,12 +91,12 @@ test('#authenticate sends an AJAX request to the sign in endpoint', function() {
       data: '{"password":"password","username":"username"}',
       dataType: 'json',
       contentType: 'application/json',
+      headers: {}
     });
 
     Ember.$.ajax.restore();
   });
 });
-
 
 test('#authenticate successfully resolves with the correct data', function() {
   sinon.spy(Ember.$, 'ajax');
@@ -109,6 +117,34 @@ test('#authenticate successfully resolves with the correct data', function() {
       deepEqual(data, {
         access_token: 'secret token!'
       });
+    });
+
+    Ember.$.ajax.restore();
+  });
+});
+
+test('#authenticate sends an AJAX request with custom headers', function() {
+  sinon.spy(Ember.$, 'ajax');
+
+  var credentials = {
+    identification: 'username',
+    password: 'password'
+  };
+
+  Configuration.customHeaders = {'X-API-KEY': '123-abc', 'X-ANOTHER-HEADER': 0};
+  App.authenticator = Token.create();
+  App.authenticator.authenticate(credentials);
+
+  Ember.run.next(function() {
+    var args = Ember.$.ajax.getCall(0).args[0];
+    delete args.beforeSend;
+    deepEqual(args, {
+      url: '/api-token-auth/',
+      type: 'POST',
+      data: '{"password":"password","username":"username"}',
+      dataType: 'json',
+      contentType: 'application/json',
+      headers: {'X-API-KEY': '123-abc', 'X-ANOTHER-HEADER': 0}
     });
 
     Ember.$.ajax.restore();

--- a/tests/unit/authenticators/token-test.js
+++ b/tests/unit/authenticators/token-test.js
@@ -44,10 +44,10 @@ test('assigns tokenPropertyName from the configuration object', function() {
   Configuration.load({}, {});
 });
 
-test('assigns customHeaders from the configuration object', function() {
-  Configuration.customHeaders = 'customHeaders';
+test('assigns custom headers from the configuration object', function() {
+  Configuration.headers = 'headers';
 
-  equal(Token.create().customHeaders, 'customHeaders');
+  equal(Token.create().headers, 'headers');
 
   Configuration.load({}, {});
 });
@@ -131,7 +131,7 @@ test('#authenticate sends an AJAX request with custom headers', function() {
     password: 'password'
   };
 
-  Configuration.customHeaders = {'X-API-KEY': '123-abc', 'X-ANOTHER-HEADER': 0};
+  Configuration.headers = {'X-API-KEY': '123-abc', 'X-ANOTHER-HEADER': 0};
   App.authenticator = Token.create();
   App.authenticator.authenticate(credentials);
 


### PR DESCRIPTION
 Add an optional customHeader configuration, wich will send custom headers on every authentication request.

Just like http://emberjs.com/api/data/classes/DS.RESTAdapter.html#toc_headers-customization
