### PR TITLE
Extract token from properties if tokenPropertyName indicates nested values

### DIFF
--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -100,7 +100,7 @@ export default Base.extend({
   restore: function(properties) {
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      if (!Ember.isEmpty(properties[_this.tokenPropertyName])) {
+      if (!Ember.isEmpty(_this.extractTokenFromProperties(properties))) {
         resolve(properties);
       } else {
         reject();
@@ -187,5 +187,17 @@ export default Base.extend({
       },
       headers: this.headers
     });
+  },
+
+  /**
+    @method extractTokenFromProperties
+    @private
+  */
+  extractTokenFromProperties: function(properties) {
+    var res = properties;
+    this.tokenPropertyName.split('.').forEach(function(e) {
+      if (res && res[e]) { res = res[e]; }
+    });
+    return res;
   }
 });


### PR DESCRIPTION
This target cases when tokenPropertyName looks like `user.token` i.e. whole user object gets stored as a result of authentication.
