### PR TITLE
Add a margin to the automatic JWT refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,24 @@ export default Ember.Controller.extend(LoginControllerMixin, {
 
 Please note, the JWT authenticator will decode a token and look for the
 expiration time found by looking up the token[Config.tokenExpireName]. It then
-calculates the difference between the current time and the token expire time
-to determine when to make the next automatic token refresh request.
+calculates the difference between the current time and the token expire time —
+from which the *refreshLeeway* is subtracted — to determine when to make the
+next automatic token refresh request.
 
-For example, your decoded token might look like this:
+For example, with the following configuration:
+
+```
+  ENV['simple-auth'] = {
+    authorizer: 'simple-auth-authorizer:token'
+  };
+  ENV['simple-auth-token'] = {
+    refreshAccessTokens: true,
+    timeFactor: 1,
+    refreshLeeway: 300 // Refresh the token 5 minutes (300s) before it expires.
+  };
+```
+
+Your decoded token might look like this:
 
 ```
 token = {
@@ -100,10 +114,11 @@ token = {
 }
 ```
 
-In this case the token expire name is using the default `exp` as set by the
-`Config.tokenExpireName` property.
+*In this case the token expire name is using the default `exp` as set by the
+`Config.tokenExpireName` property.*
 
-An automatic token refresh request would be sent out at token[Config.tokenExpireName] - now()
+If the token issued was valid for an hour, an automatic token refresh request
+would be sent out five minutes before the expiration time of the token.
 
 ## The Authorizer
 
@@ -145,5 +160,6 @@ For the JWT authenticator (in addition to the Token authenticator fields):
   refreshAccessTokens: true,
   serverTokenRefreshEndpoint: '/api-token-refresh/',
   tokenExpireName: 'exp',
+  refreshLeeway: 0,
   timeFactor: 1  // example - set to "1000" to convert incoming seconds to milliseconds.
 ```

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -35,11 +35,11 @@ export default TokenAuthenticator.extend({
   /**
     The number of seconds to subtract from the token's time of expiration when
     scheduling the automatic token refresh call.
-    @property refreshMargin
+    @property refreshLeeway
     @type Integer
     @default 0 (seconds)
   */
-  refreshMargin: 0,
+  refreshLeeway: 0,
 
   /**
     The amount of time to wait before refreshing the token - set automatically.
@@ -74,7 +74,7 @@ export default TokenAuthenticator.extend({
     this.identificationField = Configuration.identificationField;
     this.tokenPropertyName = Configuration.tokenPropertyName;
     this.refreshAccessTokens = Configuration.refreshAccessTokens;
-    this.refreshMargin = Configuration.refreshMargin;
+    this.refreshLeeway = Configuration.refreshLeeway;
     this.tokenExpireName = Configuration.tokenExpireName;
     this.timeFactor = Configuration.timeFactor;
     this.headers = Configuration.headers;
@@ -180,7 +180,7 @@ export default TokenAuthenticator.extend({
     `wait` time has passed.
 
     If both `token` and `expiresAt` are non-empty, and `expiresAt` minus the optional 
-    refres margin is greater than the calculated `now`, the token refresh will be scheduled
+    refres leeway is greater than the calculated `now`, the token refresh will be scheduled
     through Ember.run.later.
 
     @method scheduleAccessTokenRefresh
@@ -191,7 +191,7 @@ export default TokenAuthenticator.extend({
       expiresAt = this.resolveTime(expiresAt);
 
       var now = (new Date()).getTime(),
-        wait = expiresAt - now - (this.refreshMargin * 1000);
+        wait = expiresAt - now - (this.refreshLeeway * 1000);
 
       if (!Ember.isEmpty(token) && !Ember.isEmpty(expiresAt) && wait > 0) {
         Ember.run.cancel(this._refreshTokenTimeout);

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -7,7 +7,7 @@ var defaults = {
   passwordField: 'password',
   tokenPropertyName: 'token',
   refreshAccessTokens: true,
-  refreshMargin: 0,
+  refreshLeeway: 0,
   tokenExpireName: 'exp',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
@@ -101,11 +101,11 @@ export default {
   /**
     The number of seconds to subtract from the token's time of expiration when
     scheduling the automatic token refresh call.
-    @property refreshMargin
+    @property refreshLeeway
     @type Integer
     @default 0 (seconds)
   */
-  refreshMargin: defaults.refreshMargin,
+  refreshLeeway: defaults.refreshLeeway,
 
   /**
     The name for which decoded token field represents the token expire time.

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -7,6 +7,7 @@ var defaults = {
   passwordField: 'password',
   tokenPropertyName: 'token',
   refreshAccessTokens: true,
+  refreshMargin: 0,
   tokenExpireName: 'exp',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
@@ -96,6 +97,15 @@ export default {
     @default true
   */
   refreshAccessTokens: defaults.refreshAccessTokens,
+
+  /**
+    The number of seconds to subtract from the token's time of expiration when
+    scheduling the automatic token refresh call.
+    @property refreshMargin
+    @type Integer
+    @default 0 (seconds)
+  */
+  refreshMargin: defaults.refreshMargin,
 
   /**
     The name for which decoded token field represents the token expire time.

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -282,6 +282,31 @@ test('#restore does not schedule a token refresh when `expiresAt` < now.', funct
   });
 });
 
+test('#restore does not schedule a token refresh when `expiresAt` - `refreshMargin` < now.', function() {
+  var jwt = JWT.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data[jwt.tokenExpireName] = expiresAt;
+
+  // Set the refreshMargin to > expiresAt.
+  App.authenticator.refreshMargin = 120;
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function() {
+      // Check that Ember.run.later was not called.
+      deepEqual(Ember.run.later.getCall(0), null);
+    });
+  });
+});
+
 test('#authenticate sends an ajax request to the token endpoint', function() {
   sinon.spy(Ember.$, 'ajax');
 

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -282,7 +282,7 @@ test('#restore does not schedule a token refresh when `expiresAt` < now.', funct
   });
 });
 
-test('#restore does not schedule a token refresh when `expiresAt` - `refreshMargin` < now.', function() {
+test('#restore does not schedule a token refresh when `expiresAt` - `refreshLeeway` < now.', function() {
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -296,8 +296,8 @@ test('#restore does not schedule a token refresh when `expiresAt` - `refreshMarg
   data[jwt.tokenPropertyName] = token;
   data[jwt.tokenExpireName] = expiresAt;
 
-  // Set the refreshMargin to > expiresAt.
-  App.authenticator.refreshMargin = 120;
+  // Set the refreshLeeway to > expiresAt.
+  App.authenticator.refreshLeeway = 120;
 
   Ember.run(function() {
     App.authenticator.restore(data).then(function() {

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -42,8 +42,8 @@ test('refreshAccessTokens', function() {
   equal(Configuration.refreshAccessTokens, true, 'defaults to true');
 });
 
-test('refreshMargin', function() {
-  equal(Configuration.refreshMargin, 0, 'defaults to 0');
+test('refreshLeeway', function() {
+  equal(Configuration.refreshLeeway, 0, 'defaults to 0');
 });
 
 test('tokenExpireName', function() {

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -42,6 +42,10 @@ test('refreshAccessTokens', function() {
   equal(Configuration.refreshAccessTokens, true, 'defaults to true');
 });
 
+test('refreshMargin', function() {
+  equal(Configuration.refreshMargin, 0, 'defaults to 0');
+});
+
 test('tokenExpireName', function() {
   equal(Configuration.tokenExpireName, 'exp', 'defaults to "exp"');
 });


### PR DESCRIPTION
By configuring `refreshMargin` the JWT gets refreshed that many seconds
before the current token expires.

PR for #32.
