### PR TITLE
Allow for strings to be used as token data

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -12,7 +12,7 @@ import TokenAuthenticator from './token';
 
   @class JWT
   @namespace SimpleAuth.Authenticators
-  @module simple-auth-token/authenticators/jwt
+  @module simple-auth-token/authenticgators/jwt
   @extends TokenAuthenticator
 */
 export default TokenAuthenticator.extend({
@@ -254,7 +254,14 @@ export default TokenAuthenticator.extend({
     @return {object} An object with properties for the session.
   */
   getTokenData: function(token) {
-    return JSON.parse(atob(token.split('.')[1]));
+    var tokenData = atob(token.split('.')[1]);
+    
+    try {
+      return JSON.parse(tokenData);
+    } catch (e) {
+      //jshint unused:false
+      return tokenData;
+    }
   },
 
   /**

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -12,7 +12,7 @@ import TokenAuthenticator from './token';
 
   @class JWT
   @namespace SimpleAuth.Authenticators
-  @module simple-auth-token/authenticgators/jwt
+  @module simple-auth-token/authenticators/jwt
   @extends TokenAuthenticator
 */
 export default TokenAuthenticator.extend({

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -505,6 +505,6 @@ test('#getTokenData returns correct data', function() {
   var objectToken = createFakeToken(objectTokenData);
   var stringToken = createFakeToken(stringTokenData);
   
-  equal(jwt.getTokenData(objectToken), objectTokenData, 'Object data returned');
+  deepEqual(jwt.getTokenData(objectToken), objectTokenData, 'Object data returned');
   equal(jwt.getTokenData(stringToken), stringTokenData, 'String data returned');
 });

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -493,3 +493,18 @@ test('#refreshAccessToken triggers the `sessionDataUpdated` event on successful 
     deepEqual(data.token, token);
   });
 });
+
+test('#getTokenData returns correct data', function() {
+  var jwt = JWT.create();
+  
+  var stringTokenData = 'test@test.com';
+  var objectTokenData = {};
+  
+  objectTokenData[jwt.identificationField] = stringTokenData;
+
+  var objectToken = createFakeToken(objectTokenData);
+  var stringToken = createFakeToken(stringTokenData);
+  
+  equal(jwt.getTokenData(objectToken), objectTokenData, 'Object data returned');
+  equal(jwt.getTokenData(stringToken), stringTokenData, 'String data returned');
+});


### PR DESCRIPTION
Pretty much `JSON.parse` chokes if you give it a string (valid json).
