### PR TITLE
don't restore expired tokens

### DIFF
--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -215,7 +215,6 @@ test('#restore resolves when `expiresAt` is greater than `now`', function() {
       // Check that Ember.run.later was not called.
       deepEqual(Ember.run.later.getCall(0), null);
     }).catch(function (err) {
-      console.log(err.message);
       ok(false);
     });
   });

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -60,6 +60,7 @@ test('assigns timeFactor from the configuration object', function() {
 });
 
 test('#restore resolves when the data includes `token` and `expiresAt`', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -71,7 +72,7 @@ test('#restore resolves when the data includes `token` and `expiresAt`', functio
 
   var data = {};
   data[jwt.tokenPropertyName] = token;
-  data[jwt.tokenExpireName] = expiresAt;
+  data.expiresAt = expiresAt;
 
   App.server.respondWith('POST', '/api-token-refresh/', [
     201, {
@@ -83,12 +84,15 @@ test('#restore resolves when the data includes `token` and `expiresAt`', functio
   Ember.run(function() {
     App.authenticator.restore(data).then(function(content) {
       // Check that the resolved data matches the init data.
-      deepEqual(content, data);
+      equal(JSON.stringify(content), JSON.stringify(data));
+    }, function () {
+      ok(false);
     });
   });
 });
 
 test('#restore resolves when the data includes `token` and excludes `expiresAt`', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -100,7 +104,6 @@ test('#restore resolves when the data includes `token` and excludes `expiresAt`'
 
   var data = {};
   data[jwt.tokenPropertyName] = token;
-
   App.server.respondWith('POST', '/api-token-refresh/', [
     201, {
       'Content-Type': 'application/json'
@@ -110,15 +113,17 @@ test('#restore resolves when the data includes `token` and excludes `expiresAt`'
 
   Ember.run(function() {
     App.authenticator.restore(data).then(function(content) {
-      // Check that the resolved data matches the init data.
-      deepEqual(content, data);
+      equal(JSON.stringify(content), JSON.stringify(data), 'Check that the resolved data matches the init data');
+    }).catch(function () {
+      ok(false);
     });
   });
 });
 
-test('#restore rejects when `refreshAccessTokens` is false', function() {
+test('#restore rejects when `refreshAccessTokens` is false and token is expired', function() {
+  expect(1);
   var jwt = JWT.create(),
-    expiresAt = (new Date()).getTime() + 60000;
+    expiresAt = (new Date()).getTime();
 
   var token = {};
   token[jwt.identificationField] = 'test@test.com';
@@ -140,7 +145,9 @@ test('#restore rejects when `refreshAccessTokens` is false', function() {
   ]);
 
   Ember.run(function() {
-    App.authenticator.restore(data).then(null, function() {
+    App.authenticator.restore(data).then(function () {
+      ok(false);
+    }, function() {
       // Check that Ember.run.later was not called.
       deepEqual(Ember.run.later.getCall(0), null);
     });
@@ -148,6 +155,7 @@ test('#restore rejects when `refreshAccessTokens` is false', function() {
 });
 
 test('#restore rejects when `token` is excluded.', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -160,7 +168,6 @@ test('#restore rejects when `token` is excluded.', function() {
   var data = {};
   data['expiresAt'] = expiresAt;
 
-  App.authenticator.refreshAccessTokens = false;
 
   App.server.respondWith('POST', '/api-token-refresh/', [
     201, {
@@ -170,7 +177,9 @@ test('#restore rejects when `token` is excluded.', function() {
   ]);
 
   Ember.run(function() {
-    App.authenticator.restore(data).then(null, function() {
+    App.authenticator.restore(data).then(function () {
+      ok(false);
+    }, function() {
       // Check that Ember.run.later was not called.
       deepEqual(Ember.run.later.getCall(0), null);
     });
@@ -178,6 +187,7 @@ test('#restore rejects when `token` is excluded.', function() {
 });
 
 test('#restore resolves when `expiresAt` is greater than `now`', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -204,11 +214,15 @@ test('#restore resolves when `expiresAt` is greater than `now`', function() {
     App.authenticator.restore(data).then(function(content) {
       // Check that Ember.run.later was not called.
       deepEqual(Ember.run.later.getCall(0), null);
+    }).catch(function (err) {
+      console.log(err.message);
+      ok(false);
     });
   });
 });
 
 test('#restore schedules a token refresh when `refreshAccessTokens` is true.', function() {
+  expect(2);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -236,6 +250,7 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', f
 });
 
 test('#restore does not schedule a token refresh when `refreshAccessTokens` is false.', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -261,8 +276,9 @@ test('#restore does not schedule a token refresh when `refreshAccessTokens` is f
 });
 
 test('#restore does not schedule a token refresh when `expiresAt` < now.', function() {
+  expect(1);
   var jwt = JWT.create(),
-    expiresAt = (new Date()).getTime() + 60000;
+    expiresAt = (new Date()).getTime() - 10;
 
   var token = {};
   token[jwt.identificationField] = 'test@test.com';
@@ -275,7 +291,7 @@ test('#restore does not schedule a token refresh when `expiresAt` < now.', funct
   data[jwt.tokenExpireName] = expiresAt;
 
   Ember.run(function() {
-    App.authenticator.restore(data).then(function() {
+    App.authenticator.restore(data).catch(function() {
       // Check that Ember.run.later was not called.
       deepEqual(Ember.run.later.getCall(0), null);
     });
@@ -283,6 +299,7 @@ test('#restore does not schedule a token refresh when `expiresAt` < now.', funct
 });
 
 test('#restore does not schedule a token refresh when `expiresAt` - `refreshLeeway` < now.', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -300,7 +317,7 @@ test('#restore does not schedule a token refresh when `expiresAt` - `refreshLeew
   App.authenticator.refreshLeeway = 120;
 
   Ember.run(function() {
-    App.authenticator.restore(data).then(function() {
+    App.authenticator.restore(data).catch(function() {
       // Check that Ember.run.later was not called.
       deepEqual(Ember.run.later.getCall(0), null);
     });
@@ -308,6 +325,7 @@ test('#restore does not schedule a token refresh when `expiresAt` - `refreshLeew
 });
 
 test('#authenticate sends an ajax request to the token endpoint', function() {
+  expect(1);
   sinon.spy(Ember.$, 'ajax');
 
   var jwt = JWT.create();
@@ -335,6 +353,7 @@ test('#authenticate sends an ajax request to the token endpoint', function() {
 });
 
 test('#authenticate rejects with invalid credentials', function() {
+  expect(1);
   var jwt = JWT.create(),
     expiresAt = (new Date()).getTime() + 60000;
 
@@ -496,15 +515,15 @@ test('#refreshAccessToken triggers the `sessionDataUpdated` event on successful 
 
 test('#getTokenData returns correct data', function() {
   var jwt = JWT.create();
-  
+
   var stringTokenData = 'test@test.com';
   var objectTokenData = {};
-  
+
   objectTokenData[jwt.identificationField] = stringTokenData;
 
   var objectToken = createFakeToken(objectTokenData);
   var stringToken = createFakeToken(stringTokenData);
-  
+
   deepEqual(jwt.getTokenData(objectToken), objectTokenData, 'Object data returned');
   equal(jwt.getTokenData(stringToken), stringTokenData, 'String data returned');
 });


### PR DESCRIPTION
I noticed a bug then when I logged into a site, then navigated away, then after the token expired navigating back the the now expired token will be accepted and the site will act like you are logged in until you try to do something with the token at which point you get logged out.

This pull also cleans up the logic around restoring tokens, uses real error objects and cleans up some of the tests to make sure they are actually testing what they intended to test.

Previous restore logic
1.  if token exists, expiresAt exists, and data.expiresAt is greater then now
   1. if refreshAccessTokens refresh the token, then return the data
   2. reject with undefined
2. else
   1. if token is empty reject with undefined
   2. else schedule a refresh based on the time in the token and return the data

the problem was with an expired token which took path 2, 2 

new logic
1. If token is empty, reject with an error
2.  if data.expiresAt is empty
   1. set expiresAt from the token
   2. if expiresAt is still empty resolve with the data (token doesn't expire).
3. If expiresAt is NaN (shouldn't be possible any more) reject with error
4. If expiresAt is greater then now (token is not expired)
   1. If time until expiration is more then the leeway
      1. if refreshAccessTokens then schedule a refresh
      2. either way resolve data
   2. else if refreshAccessTokens
      1. refresh the access token and then return the data
   3. else reject the token (we are within the leeway so force the user to get a new token instead of one which is going to be useless very soon).
5. reject as token has expired.
