### PR TITLE
Fixes jwt authenticator restore method to schedule access token refresh after page reload

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -206,7 +206,7 @@ export default TokenAuthenticator.extend({
 
       if (!Ember.isEmpty(token) && !Ember.isEmpty(expiresAt) && wait > 0) {
         Ember.run.cancel(this._refreshTokenTimeout);
-        
+
         delete this._refreshTokenTimeout;
 
         if (!Ember.testing) {

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -104,13 +104,13 @@ export default TokenAuthenticator.extend({
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
       var now = (new Date()).getTime(),
-        expiresAt = _this.resolveTime(dataObject.get('expiresAt')),
+        expiresAt = _this.resolveTime(dataObject.get(_this.tokenExpireName)),
         token = dataObject.get(_this.tokenPropertyName);
+
       if (Ember.isEmpty(token)) {
         return reject(new Error('empty token'));
       }
-
-       if (Ember.isEmpty(expiresAt)) {
+      if (Ember.isEmpty(expiresAt)) {
         // Fetch the expire time from the token data since `expiresAt`
         // wasn't included in the data object that was passed in.
         var tokenData = _this.getTokenData(data[_this.tokenPropertyName]);
@@ -118,7 +118,6 @@ export default TokenAuthenticator.extend({
         if (Ember.isEmpty(expiresAt)) {
           return resolve(data);
         }
-
       }
       if (expiresAt !== expiresAt) {
         return reject(new Error('invalid expiration'));
@@ -127,7 +126,7 @@ export default TokenAuthenticator.extend({
         var wait = expiresAt - now - (_this.refreshLeeway * 1000);
         if (wait > 0) {
           if (_this.refreshAccessTokens) {
-            _this.scheduleAccessTokenRefresh(dataObject.get('expiresAt'), token);
+            _this.scheduleAccessTokenRefresh(dataObject.get(_this.tokenExpireName), token);
           }
           resolve(data);
         } else if (_this.refreshAccessTokens) {
@@ -207,7 +206,7 @@ export default TokenAuthenticator.extend({
 
       if (!Ember.isEmpty(token) && !Ember.isEmpty(expiresAt) && wait > 0) {
         Ember.run.cancel(this._refreshTokenTimeout);
-
+        
         delete this._refreshTokenTimeout;
 
         if (!Ember.testing) {

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -103,9 +103,9 @@ export default TokenAuthenticator.extend({
       dataObject = Ember.Object.create(data);
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      var now = (new Date()).getTime(),
-        expiresAt = _this.resolveTime(dataObject.get(_this.tokenExpireName)),
-        token = dataObject.get(_this.tokenPropertyName);
+      var now = (new Date()).getTime();
+      var expiresAt = _this.resolveTime(dataObject.get(_this.tokenExpireName));
+      var token = dataObject.get(_this.tokenPropertyName);
 
       if (Ember.isEmpty(token)) {
         return reject(new Error('empty token'));
@@ -130,7 +130,7 @@ export default TokenAuthenticator.extend({
           }
           resolve(data);
         } else if (_this.refreshAccessTokens) {
-          resolve(_this.refreshAccessToken(data.token).then(function () {
+            resolve(_this.refreshAccessToken(data.token).then(function () {
             return data;
           }));
         } else {
@@ -239,14 +239,15 @@ export default TokenAuthenticator.extend({
     return new Ember.RSVP.Promise(function(resolve, reject) {
       _this.makeRequest(_this.serverTokenRefreshEndpoint, data).then(function(response) {
         Ember.run(function() {
-          var tokenData = _this.getTokenData(response[_this.tokenPropertyName]),
-            expiresAt = tokenData[_this.tokenExpireName],
-            data = Ember.merge(response, {
-              expiresAt: expiresAt
-            });
+          var tokenData = _this.getTokenData(response[_this.tokenPropertyName]);
+          var expiresAt = tokenData[_this.tokenExpireName];
+          var tokenExpireData = {};
+
+          tokenExpireData[_this.tokenExpireName] = expiresAt;
+
+          data = Ember.merge(response, tokenExpireData);
 
           _this.scheduleAccessTokenRefresh(expiresAt, response.token);
-
           _this.trigger('sessionDataUpdated', data);
 
           resolve(response);

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -130,7 +130,8 @@ export default TokenAuthenticator.extend({
           }
           resolve(data);
         } else if (_this.refreshAccessTokens) {
-            resolve(_this.refreshAccessToken(data.token).then(function () {
+            resolve(_this.refreshAccessToken(
+              dataObject.get(_this.tokenPropertyName)).then(function () {
             return data;
           }));
         } else {

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -127,7 +127,7 @@ export default TokenAuthenticator.extend({
         var wait = expiresAt - now - (_this.refreshLeeway * 1000);
         if (wait > 0) {
           if (_this.refreshAccessTokens) {
-            _this.scheduleAccessTokenRefresh(expiresAt, token);
+            _this.scheduleAccessTokenRefresh(dataObject.get('expiresAt'), token);
           }
           resolve(data);
         } else if (_this.refreshAccessTokens) {

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -235,7 +235,7 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', f
   data[jwt.tokenPropertyName] = token;
   data[jwt.tokenExpireName] = expiresAt;
 
-  // TODO: find out of there is another way besides setting Ember.testing.
+  // TODO: find out if there is another way besides setting Ember.testing.
   Ember.testing = false;
 
   Ember.run(function() {

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -506,8 +506,8 @@ test('#refreshAccessToken triggers the `sessionDataUpdated` event on successful 
   App.authenticator.refreshAccessToken(token);
 
   App.authenticator.one('sessionDataUpdated', function(data) {
-    ok(data.expiresAt, 'Verify expiresAt was added to response');
-    ok(data.expiresAt > (new Date()).getTime(), 'Verify is greater than now');
+    ok(data[jwt.tokenExpireName], 'Verify expiresAt was added to response');
+    ok(data[jwt.tokenExpireName] > (new Date()).getTime(), 'Verify is greater than now');
     deepEqual(data.token, token);
   });
 });


### PR DESCRIPTION
The restore method was not functioning after a page reload due to inconsistency with stored token expire name... Updated it to use the tokenExpireName throughout and restored functionality
