### PR TITLE
Fix authorizer cannot build a token.

### DIFF
--- a/addon/authorizers/token.js
+++ b/addon/authorizers/token.js
@@ -94,6 +94,6 @@ export default Base.extend({
     @return {String}
   */
   buildToken: function() {
-    return this.get('session.' + this.tokenPropertyName);
+    return this.get('session.secure.' + this.tokenPropertyName);
   }
 });

--- a/tests/unit/authorizers/token-test.js
+++ b/tests/unit/authorizers/token-test.js
@@ -40,7 +40,7 @@ test('#authorize when authenticated adds token to request', function() {
   expect(3);
 
   App.authorizer.set('session.isAuthenticated', true);
-  App.authorizer.set('session.token', 'secret token!');
+  App.authorizer.set('session.secure', {token: 'secret token!'});
   App.authorizer.authorize(App.request, {});
 
   ok(setRequestHeader);
@@ -53,7 +53,8 @@ test('#authorize when authenticated adds token to request', function() {
 });
 
 test('#authorize when session does not contain token', function() {
-  App.authorizer.set('session.user_token', null);
+  App.authorizer.set('session.isAuthenticated', true);
+  App.authorizer.set('session.secure', {});
   App.authorizer.authorize(App.request, {});
 
   ok(!setRequestHeader);
@@ -61,6 +62,7 @@ test('#authorize when session does not contain token', function() {
 
 test('#authorize when session is not authenticated', function() {
   App.authorizer.set('session.isAuthenticated', false);
+  App.authorizer.set('session.secure', {token: 'secret token!'});
   App.authorizer.authorize(App.request, {});
 
   ok(!setRequestHeader);


### PR DESCRIPTION
Hi there.
I had an issue with token authorizer was unable to build token for authorizing the request and it appeared that it was trying to get it from wrong property. So here's a pull-request fixing this.

You can check that token is actually stored in `session.secure` in [`session#setup`](https://github.com/simplabs/ember-simple-auth/blob/master/packages/ember-simple-auth/lib/simple-auth/session.js#L246) method of ember-simple-auth. 
