### PR TITLE
Add basic access authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ For the Token authenticator:
 // config/environment.js
 ENV['simple-auth-token'] = {
   serverTokenEndpoint: '/api-token-auth/',
+  basicAuthentication: false,
   identificationField: 'username',
   passwordField: 'password',
   tokenPropertyName: 'token',

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -71,6 +71,7 @@ export default TokenAuthenticator.extend({
   init: function() {
     this.serverTokenEndpoint = Configuration.serverTokenEndpoint;
     this.serverTokenRefreshEndpoint = Configuration.serverTokenRefreshEndpoint;
+    this.basicAuthentication = Configuration.basicAuthentication;
     this.identificationField = Configuration.identificationField;
     this.tokenPropertyName = Configuration.tokenPropertyName;
     this.refreshAccessTokens = Configuration.refreshAccessTokens;
@@ -284,17 +285,34 @@ export default TokenAuthenticator.extend({
     @private
   */
   makeRequest: function(url, data) {
-    return Ember.$.ajax({
-      url: url,
-      type: 'POST',
-      data: JSON.stringify(data),
-      dataType: 'json',
-      contentType: 'application/json',
-      beforeSend: function(xhr, settings) {
-        xhr.setRequestHeader('Accept', settings.accepts.json);
-      },
-      headers: this.headers
-    });
+    if (this.basicAuthentication) {
+      var username = data.username,
+        password = data.password,
+        token = username + ':' + password,
+        hash = btoa(token),
+        header = "Basic " + hash;
+        return Ember.$.ajax({
+          url: url,
+          type: 'GET',
+          dataType: 'json',
+          headers: this.headers,
+          beforeSend: function (xhr) {
+            xhr.setRequestHeader("Authorization", header);
+          }
+        });
+    } else {
+      return Ember.$.ajax({
+        url: url,
+        type: 'POST',
+        data: JSON.stringify(data),
+        dataType: 'json',
+        contentType: 'application/json',
+        beforeSend: function(xhr, settings) {
+          xhr.setRequestHeader('Accept', settings.accepts.json);
+        },
+        headers: this.headers
+      });
+    }
   },
 
   /**

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -3,6 +3,7 @@ import loadConfig from './utils/load-config';
 var defaults = {
   serverTokenEndpoint: '/api-token-auth/',
   serverTokenRefreshEndpoint: '/api-token-refresh/',
+  basicAuthentication: false,
   identificationField: 'username',
   passwordField: 'password',
   tokenPropertyName: 'token',
@@ -52,6 +53,14 @@ export default {
     @default '/api-token-refresh/'
   */
   serverTokenRefreshEndpoint: defaults.serverTokenRefreshEndpoint,
+  
+  /**
+    Sets whether the authenticator uses basic authentication.
+    @property basicAuthentication
+    @type Boolean
+    @default false
+  */
+  basicAuthentication: defaults.basicAuthentication,
 
 
   /**

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -351,6 +351,35 @@ test('#authenticate sends an ajax request to the token endpoint', function() {
   });
 });
 
+test('#authenticate sends an ajax request to the token endpoint for basic authentication', function() {
+  expect(1);
+  sinon.spy(Ember.$, 'ajax');
+
+  var jwt = JWT.create();
+
+  var credentials = {
+    identification: 'username',
+    password: 'password'
+  };
+  
+  App.authenticator.basicAuthentication = true;
+
+  App.authenticator.authenticate(credentials);
+
+  Ember.run.next(function() {
+    var args = Ember.$.ajax.getCall(0).args[0];
+    delete args.beforeSend;
+    
+    deepEqual(args, {
+      url: jwt.serverTokenEndpoint,
+      type: 'GET',
+      dataType: 'json',
+      headers: {}
+    });
+    Ember.$.ajax.restore();
+  });
+});
+
 test('#authenticate rejects with invalid credentials', function() {
   expect(1);
   var jwt = JWT.create(),

--- a/tests/unit/authenticators/token-test.js
+++ b/tests/unit/authenticators/token-test.js
@@ -28,6 +28,14 @@ test('assigns serverTokenEndpoint from the configuration object', function() {
   Configuration.load({}, {});
 });
 
+test('assigns basicAuthentication from the configuration object', function() {
+  Configuration.basicAuthentication = 'basicAuthentication';
+
+  equal(Token.create().basicAuthentication, 'basicAuthentication');
+
+  Configuration.load({}, {});
+});
+
 test('assigns identificationField from the configuration object', function() {
   Configuration.identificationField = 'identificationField';
 
@@ -128,6 +136,32 @@ test('#authenticate sends an AJAX request to the sign in endpoint', function() {
       headers: {}
     });
 
+    Ember.$.ajax.restore();
+  });
+});
+
+test('#authenticate sends an AJAX request to the sign for basic authentication', function() {
+  sinon.spy(Ember.$, 'ajax');
+
+  var credentials = {
+    identification: 'username',
+    password: 'password'
+  };
+  
+  App.authenticator.basicAuthentication = true;
+
+  App.authenticator.authenticate(credentials);
+
+  Ember.run.next(function() {
+    var args = Ember.$.ajax.getCall(0).args[0];
+    delete args.beforeSend;
+    deepEqual(args, {
+      url: '/api-token-auth/',
+      type: 'GET',
+      dataType: 'json',
+      headers: {}
+    });
+    
     Ember.$.ajax.restore();
   });
 });


### PR DESCRIPTION
Hi,

I use a backend based on Express.js and Passport.js for authentication.
So I found useful to add basic authentication support to fit [how Passport implements that process](http://passportjs.org/guide/basic-digest/).

It's basically based on a config var called `basicAuthentication` sets to `false` by default (in this case it uses your previous code).
If `basicAuthentication` is set to `true`, then the username and password are combined and encoded in the Authorization header using a GET request and default contentType.

Also some tests added.

Hope it fits with your requirements and thanks for your great addon.
