### PR TITLE
Token moved to secure object inside session

### DIFF
--- a/addon/authorizers/token.js
+++ b/addon/authorizers/token.js
@@ -94,6 +94,6 @@ export default Base.extend({
     @return {String}
   */
   buildToken: function() {
-    return this.get('session.' + this.tokenPropertyName);
+    return this.get('session.secure.' + this.tokenPropertyName);
   }
 });


### PR DESCRIPTION
ember-simple-auth made a change to the session that moved the token into a sub object called "secure"
