### PR TITLE
adding support for extra params in the credentials object

### DIFF
--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -149,7 +149,11 @@ export default Base.extend({
     var authentication = {};
     authentication[this.passwordField] = credentials.password;
     authentication[this.identificationField] = credentials.identification;
-    return authentication;
+
+    delete credentials.password;
+    delete credentials.identification;
+
+    return Ember.$.extend(authentication, credentials);
   },
 
   /**

--- a/tests/unit/authenticators/token-test.js
+++ b/tests/unit/authenticators/token-test.js
@@ -163,6 +163,33 @@ test('#authenticate sends an AJAX request to the sign in endpoint with custom fi
   });
 });
 
+test('#authenticate sends AJAX requests to the sign in endpoint with extra params', function () {
+  sinon.spy(Ember.$, 'ajax');
+
+  var credentials = {
+    identification: 'username',
+    password: 'password',
+    extra: 'extra'
+  };
+
+  App.authenticator.authenticate(credentials);
+
+  Ember.run.next(function() {
+    var args = Ember.$.ajax.getCall(0).args[0];
+    delete args.beforeSend;
+    deepEqual(args, {
+      url: '/api-token-auth/',
+      type: 'POST',
+      data: '{"password":"password","username":"username","extra":"extra"}',
+      dataType: 'json',
+      contentType: 'application/json',
+      headers: {}
+    });
+
+    Ember.$.ajax.restore();
+  });
+});
+
 test('#authenticate successfully resolves with the correct data', function() {
   sinon.spy(Ember.$, 'ajax');
 


### PR DESCRIPTION
Hello José!

I'm developing an ember app for a .net backend and using your project for it. It happened to me that the .net infrastructure requires to send to the server token endpoint not only the identifier and the password but also some extra params. In my case the params are client_id and grant_type.

I did a minor change -I guess is minor- to `TokenAuthenticator#authenticate` and added the ability to retrieve extra params from the credentials object, I guess this is the easiest way to do it but I understand if you want to add an extra parameter and merge credentials with this new object.

I wait for your comments,
Gabriel
