### PR TITLE
Added jwt-resolved authenticator which takes a token in lieu of credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ token = {
 
 An automatic token refresh request would be sent out at token[Config.tokenExpireName] - now(). A good practice with regards to token refreshing is to also set a "leeway", usually no more than a few minutes, to account for clock skew when decoding JSON Web Tokens in the server-side. Some libraries like [PyJWT](https://github.com/jpadilla/pyjwt) and [ruby-jwt](https://github.com/progrium/ruby-jwt) already support this.
 
+**Resolved JWT Authenticator**
+
+Extends the JWT Token Authenticator to take an existing token instead of credentials
+
+```js
+// app/controllers/login.js
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    authenticate: function() {
+      //Assumes we have a token from somewhere else
+      let token = this.get('token');
+      let authenticator = 'simple-auth-authenticator:jwt-resolved';
+
+      this.get('session').authenticate(authenticator, token);
+    }
+  }
+});
+```
+
 ## The Authorizer
 
 The authorizer authorizes requests by adding `token` property from the session in the `Authorization` header:

--- a/addon/authenticators/jwt-resolved.js
+++ b/addon/authenticators/jwt-resolved.js
@@ -1,0 +1,42 @@
+import Ember from 'ember';
+import JwtTokenAuthenticator from './jwt';
+
+/**
+  Special type of JWT token that takes a token instead of credentials
+
+  The factory for this authenticator is registered as
+  'simple-auth-authenticator:jwt-resolved` in Ember's container.
+
+  @class JWTResolved
+  @namespace SimpleAuth.Authenticators
+  @module simple-auth-token/authenticators/jwt-resolved
+  @extends TokenAuthenticator
+*/
+export default JwtTokenAuthenticator.extend({
+
+  /**
+    Authenticates the session with the specified `token`.
+
+    It will always return a resolved promise.
+
+    An automatic token refresh will be scheduled with the new expiration date
+    from the returned refresh token. That expiration will be merged with the
+    response and the promise resolved.
+
+    @method authenticate
+    @param {Object} options The token to use
+    @return {Ember.RSVP.Promise} A promise that always resolves
+  */
+  authenticate: function(token) {
+    return new Ember.RSVP.Promise(resolve => {
+      let tokenData = this.getTokenData(token);
+      let expiresAt = tokenData[this.tokenExpireName];
+      let response  = {};
+      response[this.tokenPropertyName] = token;
+      response.expiresAt = expiresAt;
+      this.scheduleAccessTokenRefresh(expiresAt, token);
+
+      resolve(this.getResponseData(response));
+    });
+  },
+});

--- a/app/initializers/simple-auth-token.js
+++ b/app/initializers/simple-auth-token.js
@@ -1,6 +1,7 @@
 import Configuration from 'simple-auth-token/configuration';
 import TokenAuthenticator from 'simple-auth-token/authenticators/token';
 import JWTAuthenticator from 'simple-auth-token/authenticators/jwt';
+import JWTResolvedAuthenticator from 'simple-auth-token/authenticators/jwt-resolved';
 import Authorizer from 'simple-auth-token/authorizers/token';
 import ENV from '../config/environment';
 
@@ -16,5 +17,6 @@ export default {
     container.register('simple-auth-authorizer:token', Authorizer);
     container.register('simple-auth-authenticator:token', TokenAuthenticator);
     container.register('simple-auth-authenticator:jwt', JWTAuthenticator);
+    container.register('simple-auth-authenticator:jwt-resolved', JWTResolvedAuthenticator);
   }
 };

--- a/tests/unit/authenticators/jwt-resolved-test.js
+++ b/tests/unit/authenticators/jwt-resolved-test.js
@@ -1,0 +1,432 @@
+import { test, moduleForComponent } from 'ember-qunit';
+import startApp from '../../helpers/start-app';
+import Ember from 'ember';
+import JWTResolved from 'simple-auth-token/authenticators/jwt-resolved';
+import Configuration from 'simple-auth-token/configuration';
+
+var App;
+
+var createFakeToken = function(obj) {
+  var token = window.btoa(JSON.stringify(obj));
+  return 'a.' + token + '.b';
+};
+
+module('JWT Resolved Authenticator', {
+  setup: function() {
+    App = startApp();
+    App.xhr = sinon.useFakeXMLHttpRequest();
+    App.server = sinon.fakeServer.create();
+    App.server.autoRespond = true;
+    App.authenticator = JWTResolved.create();
+    sinon.spy(Ember.run, 'later');
+  },
+  teardown: function() {
+    Ember.run(App, App.destroy);
+    App.xhr.restore();
+    Ember.run.later.restore();
+  }
+});
+
+test('assigns serverTokenRefreshEndpoint from the configuration object', function() {
+  Configuration.serverTokenRefreshEndpoint = 'serverTokenRefreshEndpoint';
+
+  equal(JWTResolved.create().serverTokenRefreshEndpoint, 'serverTokenRefreshEndpoint');
+
+  Configuration.load({}, {});
+});
+
+test('assigns refreshAccessTokens from the configuration object', function() {
+  Configuration.refreshAccessTokens = 'refreshAccessTokens';
+
+  equal(JWTResolved.create().refreshAccessTokens, 'refreshAccessTokens');
+
+  Configuration.load({}, {});
+});
+
+test('assigns tokenExpireName from the configuration object', function() {
+  Configuration.tokenExpireName = 'tokenExpireName';
+
+  equal(JWTResolved.create().tokenExpireName, 'tokenExpireName');
+
+  Configuration.load({}, {});
+});
+
+test('assigns timeFactor from the configuration object', function() {
+  Configuration.timeFactor = 'timeFactor';
+
+  equal(JWTResolved.create().timeFactor, 'timeFactor');
+
+  Configuration.load({}, {});
+});
+
+test('#restore resolves when the data includes `token` and `expiresAt`', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data.expiresAt = expiresAt;
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function(content) {
+      // Check that the resolved data matches the init data.
+      equal(JSON.stringify(content), JSON.stringify(data));
+    }, function () {
+      ok(false);
+    });
+  });
+});
+
+test('#restore resolves when the data includes `token` and excludes `expiresAt`', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  App.server.respondWith('POST', '/api-token-refresh/', [
+    201, {
+      'Content-Type': 'application/json'
+    },
+    '{ "token": "' + token + '"}'
+  ]);
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function(content) {
+      equal(JSON.stringify(content), JSON.stringify(data), 'Check that the resolved data matches the init data');
+    }).catch(function () {
+      ok(false);
+    });
+  });
+});
+
+test('#restore rejects when `refreshAccessTokens` is false and token is expired', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime();
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data['expiresAt'] = expiresAt;
+
+  App.authenticator.refreshAccessTokens = false;
+
+  App.server.respondWith('POST', '/api-token-refresh/', [
+    201, {
+      'Content-Type': 'application/json'
+    },
+    '{ "token": "' + token + '"}'
+  ]);
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function () {
+      ok(false);
+    }, function() {
+      // Check that Ember.run.later was not called.
+      deepEqual(Ember.run.later.getCall(0), null);
+    });
+  });
+});
+
+test('#restore rejects when `token` is excluded.', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data['expiresAt'] = expiresAt;
+
+
+  App.server.respondWith('POST', '/api-token-refresh/', [
+    201, {
+      'Content-Type': 'application/json'
+    },
+    '{ "token": "' + token + '"}'
+  ]);
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function () {
+      ok(false);
+    }, function() {
+      // Check that Ember.run.later was not called.
+      deepEqual(Ember.run.later.getCall(0), null);
+    });
+  });
+});
+
+test('#restore resolves when `expiresAt` is greater than `now`', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data[jwt.tokenExpireName] = expiresAt;
+
+  App.authenticator.refreshAccessTokens = false;
+
+  App.server.respondWith('POST', '/api-token-refresh/', [
+    201, {
+      'Content-Type': 'application/json'
+    },
+    '{ "token": "' + token + '"}'
+  ]);
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function(content) {
+      // Check that Ember.run.later was not called.
+      deepEqual(Ember.run.later.getCall(0), null);
+    }).catch(function (err) {
+      ok(false);
+    });
+  });
+});
+
+test('#restore schedules a token refresh when `refreshAccessTokens` is true.', function() {
+  expect(2);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data[jwt.tokenExpireName] = expiresAt;
+
+  // TODO: find out if there is another way besides setting Ember.testing.
+  Ember.testing = false;
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function(content) {
+      // Check that Ember.run.later ran.
+      var spyCall = Ember.run.later.getCall(0);
+      deepEqual(spyCall.args[1], App.authenticator.refreshAccessToken);
+      deepEqual(spyCall.args[2], token);
+    });
+  });
+});
+
+test('#restore does not schedule a token refresh when `refreshAccessTokens` is false.', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data[jwt.tokenExpireName] = expiresAt;
+
+  App.authenticator.refreshAccessTokens = false;
+
+  Ember.run(function() {
+    App.authenticator.restore(data).then(function(content) {
+      // Check that Ember.run.later ran.
+      var spyCall = Ember.run.later.getCall(0);
+      deepEqual(spyCall, null);
+    });
+  });
+});
+
+test('#restore does not schedule a token refresh when `expiresAt` < now.', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() - 10;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data[jwt.tokenExpireName] = expiresAt;
+
+  Ember.run(function() {
+    App.authenticator.restore(data).catch(function() {
+      // Check that Ember.run.later was not called.
+      deepEqual(Ember.run.later.getCall(0), null);
+    });
+  });
+});
+
+test('#restore does not schedule a token refresh when `expiresAt` - `refreshLeeway` < now.', function() {
+  expect(1);
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  var data = {};
+  data[jwt.tokenPropertyName] = token;
+  data[jwt.tokenExpireName] = expiresAt;
+
+  // Set the refreshLeeway to > expiresAt.
+  App.authenticator.refreshLeeway = 120;
+
+  Ember.run(function() {
+    App.authenticator.restore(data).catch(function() {
+      // Check that Ember.run.later was not called.
+      deepEqual(Ember.run.later.getCall(0), null);
+    });
+  });
+});
+
+test('#authenticate schedules a token refresh when `refreshAccessTokens` is true', function() {
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+  Ember.testing = false;
+  Ember.run(function() {
+    App.authenticator.authenticate(token).then(function(content) {
+      var spyCall = Ember.run.later.getCall(0);
+      deepEqual(spyCall.args[1], App.authenticator.refreshAccessToken);
+      deepEqual(spyCall.args[2], token);
+    });
+  });
+});
+
+test('#authenticate does not schedule a token refresh when `refreshAccessTokens` is false', function() {
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  App.authenticator.refreshAccessTokens = false;
+
+  // TODO: find out of there is another way besides setting Ember.testing.
+  Ember.testing = false;
+
+  Ember.run(function() {
+    App.authenticator.authenticate(token).then(function(content) {
+      // Check that Ember.run.later ran.
+      var spyCall = Ember.run.later.getCall(0);
+      deepEqual(spyCall, null);
+    });
+  });
+});
+
+test('#refreshAccessToken makes an AJAX request to the token endpoint.', function() {
+  sinon.spy(Ember.$, 'ajax');
+
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  App.authenticator.refreshAccessToken(token);
+
+  Ember.run.next(function() {
+    var args = Ember.$.ajax.getCall(0).args[0];
+    delete args.beforeSend;
+    deepEqual(args, {
+      url: jwt.serverTokenRefreshEndpoint,
+      type: 'POST',
+      data: JSON.stringify({
+        'token': token
+      }),
+      dataType: 'json',
+      contentType: 'application/json',
+      headers: {}
+    });
+    Ember.$.ajax.restore();
+  });
+});
+
+test('#refreshAccessToken triggers the `sessionDataUpdated` event on successful request.', function() {
+  var jwt = JWTResolved.create(),
+    expiresAt = (new Date()).getTime() + 60000;
+
+  var token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  App.server.respondWith('POST', jwt.serverTokenRefreshEndpoint, [
+    201, {
+      'Content-Type': 'application/json'
+    },
+    '{ "token": "' + token + '"}'
+  ]);
+
+  App.authenticator.refreshAccessToken(token);
+
+  App.authenticator.one('sessionDataUpdated', function(data) {
+    ok(data[jwt.tokenExpireName], 'Verify expiresAt was added to response');
+    ok(data[jwt.tokenExpireName] > (new Date()).getTime(), 'Verify is greater than now');
+    deepEqual(data.token, token);
+  });
+});
+
+test('#getTokenData returns correct data', function() {
+  var jwt = JWTResolved.create();
+
+  var stringTokenData = 'test@test.com';
+  var objectTokenData = {};
+
+  objectTokenData[jwt.identificationField] = stringTokenData;
+
+  var objectToken = createFakeToken(objectTokenData);
+  var stringToken = createFakeToken(stringTokenData);
+
+  deepEqual(jwt.getTokenData(objectToken), objectTokenData, 'Object data returned');
+  equal(jwt.getTokenData(stringToken), stringTokenData, 'String data returned');
+});


### PR DESCRIPTION
Extends the JWT Token Authenticator to take an existing token instead of credentials.

```
let authenticator = 'simple-auth-authenticator:jwt-resolved';
this.get('session').authenticate(authenticator, token);
```

Fixes #64 for example.  I needed this functionality because I have a pluggable authentication system on my backend.  While it CAN take a username / password it has other methods which give me access to a token without needed to submit a form.

This could be done in a custom authenticator as well I suppose, but I figure it might be useful for others.

I wasn't able to figure out how to test if authentication had worked so I left the 'authenticate takes the token' test commented out in case you knew what things I could assert there.  Otherwise I can just pull it out and rebase this PR.

I couldn't come up with a better name for this.  Any thoughts?
