### PR TITLE
return raw xhr object to allow more flexibility with error handling

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -181,7 +181,7 @@ export default TokenAuthenticator.extend({
         });
       }, function(xhr) {
         Ember.run(function() {
-          reject(xhr.responseJSON || xhr.responseText);
+          reject(xhr);
         });
       });
     });

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -334,7 +334,10 @@ test('#authenticate sends an ajax request to the token endpoint', function() {
     password: 'password'
   };
 
-  App.authenticator.authenticate(credentials);
+  App.authenticator.authenticate(credentials).catch(function(err) {
+    // because authenticate() rejects the promise and the error is no longer empty,
+    // we need to handle the error case in order for the test to pass...
+  });
 
   Ember.run.next(function() {
     var args = Ember.$.ajax.getCall(0).args[0];


### PR DESCRIPTION
In some cases, `responseJSON` or `responseText` may be `undefined`. For example, if the API is down, jQuery will return `status: 0`, but `responseJSON` will be `undefined`. Currently, this will be difficult to deal with. Returning the raw `xhr` object will allow for more flexibility when determining how to deal with specific types of errors.
