### PR TITLE
Trigger sessionDataInvalidated on reject of a refresh

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -256,6 +256,7 @@ export default TokenAuthenticator.extend({
         });
       }, function(xhr, status, error) {
         Ember.Logger.warn('Access token could not be refreshed - server responded with ' + error + '.');
+        _this.trigger('sessionDataInvalidated', data);
         reject();
       });
     });


### PR DESCRIPTION
When rejecting we are not triggering the sessionDataInvalidated.  This event is handled by session and eventually redirects client to RootURL.
