### PR TITLE
Update JWT refreshAccessToken to behave more like authenticate.

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -238,12 +238,14 @@ export default TokenAuthenticator.extend({
           const expiresAt = Ember.get(tokenData, this.tokenExpireName);
           const tokenExpireData = {};
 
+          this.scheduleAccessTokenRefresh(expiresAt, resToken);
+
           tokenExpireData[this.tokenExpireName] = expiresAt;
 
-          data = Ember.merge(response, tokenExpireData);
+          response = Ember.merge(response, tokenExpireData);
+          response = this.getResponseData(response);
 
-          this.scheduleAccessTokenRefresh(expiresAt, resToken);
-          this.trigger('sessionDataUpdated', data);
+          this.trigger('sessionDataUpdated', response);
 
           resolve(response);
         });


### PR DESCRIPTION
I'm overriding the handy getResponseData function to stash some additional attributes returned in the token, in the session.  This works great.  However when the token is refreshed, getResponseData is never called.

This patch updates refreshAccessToken to behave like the initial authenticate function.
