### PR TITLE
Allow generic options to the token authenticators

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ For the Token authenticator:
 // config/environment.js
 ENV['ember-simple-auth-token'] = {
   serverTokenEndpoint: '/api/token-auth/',
-  identificationField: 'username',
-  passwordField: 'password',
   tokenPropertyName: 'token',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -71,8 +71,6 @@ export default TokenAuthenticator.extend({
   init() {
     this.serverTokenEndpoint = Configuration.serverTokenEndpoint;
     this.serverTokenRefreshEndpoint = Configuration.serverTokenRefreshEndpoint;
-    this.identificationField = Configuration.identificationField;
-    this.passwordField = Configuration.passwordField;
     this.tokenPropertyName = Configuration.tokenPropertyName;
     this.refreshAccessTokens = Configuration.refreshAccessTokens;
     this.refreshLeeway = Configuration.refreshLeeway;
@@ -160,9 +158,7 @@ export default TokenAuthenticator.extend({
   authenticate(credentials, headers) {
 
     return new Ember.RSVP.Promise((resolve, reject) => {
-      const data = this.getAuthenticateData(credentials);
-
-      this.makeRequest(this.serverTokenEndpoint, data, headers).then(response => {
+      this.makeRequest(this.serverTokenEndpoint, credentials, headers).then(response => {
         Ember.run(() => {
           const token = Ember.get(response, this.tokenPropertyName);
           const tokenData = this.getTokenData(token);

--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -27,32 +27,6 @@ export default Base.extend({
   serverTokenEndpoint: '/api/token-auth/',
 
   /**
-    The attribute-name that is used for the identification field when sending the
-    authentication data to the server.
-
-    This value can be configured via
-    [`SimpleAuth.Configuration.Token#identificationField`](#SimpleAuth-Configuration-Token-identificationField).
-
-    @property identificationField
-    @type String
-    @default 'username'
-  */
-  identificationField: 'username',
-
-  /**
-    The attribute-name that is used for the password field when sending the
-    authentication data to the server.
-
-    This value can be configured via
-    [`SimpleAuth.Configuration.Token#passwordfield`](#SimpleAuth-Configuration-Token-passwordfield).
-
-    @property passwordField
-    @type String
-    @default 'password'
-  */
-  passwordField: 'password',
-
-  /**
     The name of the property in session that contains token used for authorization.
 
     This value can be configured via
@@ -82,8 +56,6 @@ export default Base.extend({
   */
   init() {
     this.serverTokenEndpoint = Configuration.serverTokenEndpoint;
-    this.identificationField = Configuration.identificationField;
-    this.passwordField = Configuration.passwordField;
     this.tokenPropertyName = Configuration.tokenPropertyName;
     this.headers = Configuration.headers;
   },
@@ -125,9 +97,7 @@ export default Base.extend({
   */
   authenticate(credentials, headers) {
     return new Ember.RSVP.Promise((resolve, reject) => {
-      const data = this.getAuthenticateData(credentials);
-
-      this.makeRequest(data, headers).then(response => {
+      this.makeRequest(credentials, headers).then(response => {
         Ember.run(() => {
           resolve(this.getResponseData(response));
         });
@@ -135,21 +105,6 @@ export default Base.extend({
         Ember.run(() => { reject(xhr.responseJSON || xhr.responseText); });
       });
     });
-  },
-
-  /**
-    Returns an object used to be sent for authentication.
-
-    @method getAuthenticateData
-    @return {object} An object with properties for authentication.
-  */
-  getAuthenticateData(credentials) {
-    const authentication = {
-      [this.passwordField]: credentials.password,
-      [this.identificationField]: credentials.identification
-    };
-
-    return authentication;
   },
 
   /**

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -3,8 +3,6 @@ import loadConfig from './utils/load-config';
 var defaults = {
   serverTokenEndpoint: '/api/token-auth/',
   serverTokenRefreshEndpoint: '/api/token-refresh/',
-  identificationField: 'username',
-  passwordField: 'password',
   tokenPropertyName: 'token',
   refreshAccessTokens: true,
   refreshLeeway: 0,
@@ -53,30 +51,6 @@ export default {
   */
   serverTokenRefreshEndpoint: defaults.serverTokenRefreshEndpoint,
 
-
-  /**
-    The attribute-name that is used for the identification field when sending
-    the authentication data to the server.
-
-    @property identificationField
-    @readOnly
-    @static
-    @type String
-    @default 'username'
-  */
-  identificationField: defaults.identificationField,
-
-  /**
-    The attribute-name that is used for the password field when sending
-    the authentication data to the server.
-
-    @property passwordField
-    @readOnly
-    @static
-    @type String
-    @default 'password'
-  */
-  passwordField: defaults.passwordField,
 
   /**
     The name of the property in session that contains token

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -82,7 +82,7 @@ test('#restore resolves when the data includes `token` and `expiresAt`', assert 
   sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -118,7 +118,7 @@ test('#restore resolves when the data includes `token` and excludes `expiresAt`'
   sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -149,7 +149,7 @@ test('#restore rejects when `refreshAccessTokens` is false and token is expired'
     expiresAt = 0;
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -184,7 +184,7 @@ test('#restore rejects when `token` is excluded.', assert => {
     expiresAt = 3;
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -219,7 +219,7 @@ test('#restore resolves when `expiresAt` is greater than `now`', assert => {
   sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -258,7 +258,7 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', a
   sinon.stub(App.authenticator, 'refreshAccessToken', () => { return null; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -268,7 +268,7 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', a
   data[jwt.tokenExpireName] = expiresAt;
 
   const refreshedToken = {};
-  refreshedToken[jwt.identificationField] = 'test@test.com';
+  refreshedToken['email'] = 'test@test.com';
   refreshedToken[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(refreshedToken);
@@ -303,7 +303,7 @@ test('#restore does not schedule a token refresh when `refreshAccessTokens` is f
   sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -330,7 +330,7 @@ test('#restore does not schedule a token refresh when `expiresAt` <= `now`.', as
     expiresAt = -1;
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -354,7 +354,7 @@ test('#restore does not schedule a token refresh when `expiresAt` - `refreshLeew
     expiresAt = getConvertedTime(6000);
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -399,7 +399,7 @@ test('#restore schedule access token refresh and refreshes it when time is appro
   sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -423,7 +423,7 @@ test('#restore schedule access token refresh and refreshes it when time is appro
   sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
 
   const refreshedToken = {};
-  refreshedToken[jwt.identificationField] = 'test@test.com';
+  refreshedToken['email'] = 'test@test.com';
   refreshedToken[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(refreshedToken);
@@ -460,7 +460,7 @@ test('#authenticate sends an ajax request to the token endpoint', assert => {
     assert.deepEqual(args, {
       url: jwt.serverTokenEndpoint,
       method: 'POST',
-      data: '{"password":"password","username":"username"}',
+      data: '{"identification":"username","password":"password"}',
       dataType: 'json',
       contentType: 'application/json',
       headers: {}
@@ -498,7 +498,7 @@ test('#authenticate schedules a token refresh when `refreshAccessTokens` is true
     expiresAt = new Date().getTime() + 300000;
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -529,7 +529,7 @@ test('#authenticate does not schedule a token refresh when `refreshAccessTokens`
     expiresAt = 3;
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -562,7 +562,7 @@ test('#refreshAccessToken makes an AJAX request to the token endpoint.', assert 
     expiresAt = 3;
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -590,7 +590,7 @@ test('#refreshAccessToken triggers the `sessionDataUpdated` event on successful 
   sinon.stub(App.authenticator, 'scheduleAccessTokenRefresh', () => { return null; });
 
   let token = {};
-  token[jwt.identificationField] = 'test@test.com';
+  token['email'] = 'test@test.com';
   token[jwt.tokenExpireName] = expiresAt;
 
   token = createFakeToken(token);
@@ -618,7 +618,7 @@ test('#getTokenData returns correct data', assert => {
   const stringTokenData = 'test@test.com';
   const objectTokenData = {};
 
-  objectTokenData[jwt.identificationField] = stringTokenData;
+  objectTokenData['email'] = stringTokenData;
 
   const objectToken = createFakeToken(objectTokenData);
   const stringToken = createFakeToken(stringTokenData);

--- a/tests/unit/authenticators/token-test.js
+++ b/tests/unit/authenticators/token-test.js
@@ -31,22 +31,6 @@ test('assigns serverTokenEndpoint from the configuration object', assert => {
   Configuration.load({}, {});
 });
 
-test('assigns identificationField from the configuration object', assert => {
-  Configuration.identificationField = 'identificationField';
-
-  assert.equal(Token.create().identificationField, 'identificationField');
-
-  Configuration.load({}, {});
-});
-
-test('assigns passwordField from the configuration object', assert => {
-  Configuration.passwordField = 'passwordField';
-
-  assert.equal(Token.create().passwordField, 'passwordField');
-
-  Configuration.load({}, {});
-});
-
 test('assigns tokenPropertyName from the configuration object', assert => {
   Configuration.tokenPropertyName = 'tokenPropertyName';
 
@@ -123,34 +107,7 @@ test('#authenticate sends an AJAX request to the sign in endpoint', assert => {
     assert.deepEqual(args, {
       url: '/api/token-auth/',
       method: 'POST',
-      data: '{"password":"password","username":"username"}',
-      dataType: 'json',
-      contentType: 'application/json',
-      headers: {}
-    });
-  });
-});
-
-test('#authenticate sends an AJAX request to the sign in endpoint with custom fields', assert => {
-  const credentials = {
-    identification: 'username',
-    password: 'password'
-  };
-
-  Configuration.identificationField = 'api-user';
-  Configuration.passwordField = 'api-key';
-
-  App.authenticator = Token.create();
-  App.authenticator.authenticate(credentials);
-
-  Ember.run(() => {
-    var args = Ember.$.ajax.getCall(0).args[0];
-    delete args.beforeSend;
-
-    assert.deepEqual(args, {
-      url: '/api/token-auth/',
-      method: 'POST',
-      data: '{"api-key":"password","api-user":"username"}',
+      data: '{"identification":"username","password":"password"}',
       dataType: 'json',
       contentType: 'application/json',
       headers: {}
@@ -198,7 +155,7 @@ test('#authenticate sends an AJAX request with custom headers', assert => {
     assert.deepEqual(args, {
       url: '/api/token-auth/',
       method: 'POST',
-      data: '{"password":"password","username":"username"}',
+      data: '{"identification":"username","password":"password"}',
       dataType: 'json',
       contentType: 'application/json',
       headers: {

--- a/tests/unit/configuration.js
+++ b/tests/unit/configuration.js
@@ -18,10 +18,6 @@ test('serverTokenEndpoint', assert => {
   assert.equal(Configuration.serverTokenEndpoint, '/api/token-auth/', 'defaults to "/api/token-auth/"');
 });
 
-test('identificationField', assert => {
-  assert.equal(Configuration.identificationField, 'username', 'defaults to "username"');
-});
-
 test('tokenPropertyName', assert => {
   assert.equal(Configuration.tokenPropertyName, 'token', 'defaults to "token"');
 });


### PR DESCRIPTION
Consider this use case:

``` Javascript
signInWithGoogle() {
  const self = this;

  this.get('torii').open('google-oauth2').then(function (auth_code) {
    return self.get('session').authenticate('authenticator:jwt', auth_code);
  }).catch(function(error) {
   // error code goes here
  });
}
```

When a user grants access to his google account, Google oauth2 service sends back an authorization code. `auth_code` is a hash which contains three fields: `authorizationCode`, `provider`, `redirectUri`. The authenticator sends this hash at the token endpoint with which the server request the provider for the protected resources, creates a user account if needed, generates its own token and sends it back to the client.

Current `ember-simple-auth-token` restricts the hash to `password` and `username` only. That's why the above use case isn't possible. Removing the restriction will allow this addon to be used in use cases beyond just `password` and `username` scenario. It wont affect username/password authentication either. What is sent to the token endpoint will depend on what credentials is passed to the authenticate method.  

This PR removes the restriction and cleans up a lot of code related to the restriction.
