### PR TITLE
Adds token validation on handleAuthResponse

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -164,8 +164,13 @@ export default TokenAuthenticator.extend({
 
       this.makeRequest(this.serverTokenEndpoint, data, headers).then(response => {
         Ember.run(() => {
-          const sessionData = this.handleAuthResponse(response, reject);
-          resolve(sessionData);
+          const sessionData = this.handleAuthResponse(response);
+
+          try {
+            resolve(sessionData);
+          } catch(error) {
+            reject(new Error(error));
+          }
         });
       }, xhr => {
         Ember.run(() => { reject(xhr.responseJSON || xhr.responseText); });
@@ -221,7 +226,14 @@ export default TokenAuthenticator.extend({
     return new Ember.RSVP.Promise((resolve, reject) => {
       this.makeRequest(this.serverTokenRefreshEndpoint, data, headers).then(response => {
         Ember.run(() => {
-          const sessionData = this.handleAuthResponse(response, reject);
+          const sessionData = this.handleAuthResponse(response);
+
+          try {
+            resolve(sessionData);
+          } catch(error) {
+            reject(new Error(error));
+          }
+
           this.trigger('sessionDataUpdated', sessionData);
           resolve(sessionData);
         });
@@ -336,11 +348,11 @@ export default TokenAuthenticator.extend({
     @method handleAuthResponse
     @private
    */
-  handleAuthResponse(response, reject) {
+  handleAuthResponse(response) {
     const token = Ember.get(response, this.tokenPropertyName);
 
     if(Ember.isEmpty(token)) {
-      return reject(new Error('empty token'));
+      throw new Error('TOKEN IS EMPTY OR A BETTER WARNING');
     }
 
     const tokenData = this.getTokenData(token);

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -352,7 +352,7 @@ export default TokenAuthenticator.extend({
     const token = Ember.get(response, this.tokenPropertyName);
 
     if(Ember.isEmpty(token)) {
-      throw new Error('TOKEN IS EMPTY OR A BETTER WARNING');
+      throw new Error('Token is empty. Please check your backend response.');
     }
 
     const tokenData = this.getTokenData(token);

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -164,9 +164,9 @@ export default TokenAuthenticator.extend({
 
       this.makeRequest(this.serverTokenEndpoint, data, headers).then(response => {
         Ember.run(() => {
-          const sessionData = this.handleAuthResponse(response);
-
           try {
+            const sessionData = this.handleAuthResponse(response);
+
             resolve(sessionData);
           } catch(error) {
             reject(new Error(error));
@@ -226,11 +226,11 @@ export default TokenAuthenticator.extend({
     return new Ember.RSVP.Promise((resolve, reject) => {
       this.makeRequest(this.serverTokenRefreshEndpoint, data, headers).then(response => {
         Ember.run(() => {
-          const sessionData = this.handleAuthResponse(response);
-
           try {
-            resolve(sessionData);
+            const sessionData = this.handleAuthResponse(response);
+
             this.trigger('sessionDataUpdated', sessionData);
+            resolve(sessionData);
           } catch(error) {
             reject(new Error(error));
           }

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -169,7 +169,7 @@ export default TokenAuthenticator.extend({
 
             resolve(sessionData);
           } catch(error) {
-            reject(new Error(error));
+            reject(error);
           }
         });
       }, xhr => {
@@ -232,7 +232,7 @@ export default TokenAuthenticator.extend({
             this.trigger('sessionDataUpdated', sessionData);
             resolve(sessionData);
           } catch(error) {
-            reject(new Error(error));
+            reject(error);
           }
         });
       }, (xhr, status, error) => {

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -230,12 +230,10 @@ export default TokenAuthenticator.extend({
 
           try {
             resolve(sessionData);
+            this.trigger('sessionDataUpdated', sessionData);
           } catch(error) {
             reject(new Error(error));
           }
-
-          this.trigger('sessionDataUpdated', sessionData);
-          resolve(sessionData);
         });
       }, (xhr, status, error) => {
         Ember.Logger.warn(`Access token could not be refreshed - server responded with ${error}.`);


### PR DESCRIPTION
Adds token validation on handleAuthResponse. Users should not get an error Uncaught TypeError: Cannot read property 'split' of undefined
