### PR TITLE
fix deprecation Ember.merge for 2.5.0

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import Configuration from '../configuration';
 import TokenAuthenticator from './token';
 
+const assign = Ember.assign || Ember.merge;
+
 /**
   JWT (JSON Web Token) Authenticator that supports automatic token refresh.
 
@@ -344,6 +346,6 @@ export default TokenAuthenticator.extend({
 
     this.scheduleAccessTokenRefresh(expiresAt, token);
 
-    return Ember.merge(this.getResponseData(response), tokenExpireData);
+    return assign(this.getResponseData(response), tokenExpireData);
   }
 });


### PR DESCRIPTION
DEPRECATION: Usage of `Ember.merge` is deprecated, use `Ember.assign` instead. [deprecation id: ember-metal.merge]

More info: emberjs/ember.js#12303

Setup:

```
Ember             : 2.5.0-beta.3
Ember Data        : 2.5.0-beta.3
jQuery            : 2.2.1
Ember Simple Auth : 1.1.0-beta.3
```
