### PR TITLE
Fixed a bug with restoring token data from local storage

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -116,7 +116,7 @@ export default TokenAuthenticator.extend({
       if (Ember.isEmpty(expiresAt)) {
         // Fetch the expire time from the token data since `expiresAt`
         // wasn't included in the data object that was passed in.
-        const tokenData = this.getTokenData(Ember.get(token, this.tokenPropertyName));
+        const tokenData = this.getTokenData(token);
 
         expiresAt = this.resolveTime(tokenData[this.tokenExpireName]);
         if (Ember.isEmpty(expiresAt)) {

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -177,6 +177,42 @@ test('#restore rejects when `refreshAccessTokens` is false and token is expired'
   });
 });
 
+test('#restore resolves when `expiresAt` is empty but the data includes a nested tokenPropertyName', assert => {
+  assert.expect(1);
+
+  const jwt = JWT.create(),
+    currentTime = getConvertedTime(10000),
+    expiresAt = null;
+
+  sinon.stub(App.authenticator, 'getCurrentTime', () => { return currentTime; });
+  let authenticator = App.authenticator;
+  authenticator.tokenPropertyName = 'auth.nested.token';
+
+  let token = {};
+  token[jwt.identificationField] = 'test@test.com';
+  token[jwt.tokenExpireName] = expiresAt;
+
+  token = createFakeToken(token);
+
+  const data = {
+    auth: {
+      nested: {
+        token: token
+      }
+    }
+  };
+  data[jwt.tokenExpireName] = expiresAt;
+
+  Ember.run(() => {
+    App.authenticator.restore(data).then(content => {
+    // Check that the resolved data matches the init data.
+      assert.equal(JSON.stringify(content), JSON.stringify(data));
+    }, () => {
+      assert.ok(false);
+    });
+  });
+});
+
 test('#restore rejects when `token` is excluded.', assert => {
   assert.expect(1);
 


### PR DESCRIPTION
As part of 1.1.0, a new bug was introduced with restoring token data from local storage (the line in question was changed in https://github.com/jpadilla/ember-simple-auth-token/pull/145/commits/ba23ed4741f5d7048478555b113ba58da545f0f2 )

This tweaks what object the token is being retrieved from to use the pre-fetched token (instead of trying to fetch the token from the token 😄 )
