### PR TITLE
Trigger sessionDataInvalidated event on failed token refresh

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -239,6 +239,11 @@ export default TokenAuthenticator.extend({
         });
       }, (xhr, status, error) => {
         Ember.Logger.warn(`Access token could not be refreshed - server responded with ${error}.`);
+
+        if (xhr.status === 401 || xhr.status === 403) {
+          this.trigger('sessionDataInvalidated');
+        }
+
         reject();
       });
     });


### PR DESCRIPTION
Invalidate the session if server responds with client errors 401 Unauthorized or 403 Forbidden upon refreshing an expiring JWT. As outlined in #104.
