### PR TITLE
Added support for authenticator custom Accept header

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -299,7 +299,9 @@ export default TokenAuthenticator.extend({
       contentType: 'application/json',
       headers: this.headers,
       beforeSend: (xhr, settings) => {
-        xhr.setRequestHeader('Accept', settings.accepts.json);
+        if (Ember.isEmpty(this.headers['Accept'])) {
+          xhr.setRequestHeader('Accept', settings.accepts.json);
+        }
 
         if (headers) {
           Object.keys(headers).forEach(key => {

--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -188,7 +188,9 @@ export default Base.extend({
       contentType: 'application/json',
       headers: this.headers,
       beforeSend: (xhr, settings) => {
-        xhr.setRequestHeader('Accept', settings.accepts.json);
+        if (Ember.isEmpty(this.headers['Accept'])) {
+          xhr.setRequestHeader('Accept', settings.accepts.json);
+        }
 
         if (headers) {
           Object.keys(headers).forEach(key => {


### PR DESCRIPTION
Closes #159 — allows for custom Accept header definition in consuming app for JWT and Token authenticators
