### PR TITLE
Fixed broken test.

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -201,7 +201,7 @@ export default TokenAuthenticator.extend({
 
       if (!Ember.isEmpty(token) && !Ember.isEmpty(expiresAt) && wait > 0) {
         Ember.run.cancel(this._refreshTokenTimeout);
-        Reflect.deleteProperty(this, '_refreshTokenTimeout');
+        delete this._refreshTokenTimeout;
         this._refreshTokenTimeout = Ember.run.later(this, this.refreshAccessToken, token, wait);
       }
     }
@@ -325,7 +325,7 @@ export default TokenAuthenticator.extend({
   */
   invalidate() {
     Ember.run.cancel(this._refreshTokenTimeout);
-    Reflect.deleteProperty(this, '_refreshTokenTimeout');
+    delete this._refreshTokenTimeout;
     return new Ember.RSVP.resolve();
   },
 


### PR DESCRIPTION
`Reflect.deleteProperty` was causing broken tests when trying to delete `_refreshTokenTimeout `. I assume this was due to low support for it. Reverted to previous `delete` method.