### PR TITLE
Removed timeFactor config option and fixed refresh time calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ For example, with the following configuration:
   };
   ENV['ember-simple-auth-token'] = {
     refreshAccessTokens: true,
-    timeFactor: 1,
     refreshLeeway: 300 // Refresh the token 5 minutes (300s) before it expires.
   };
 ```
@@ -193,8 +192,7 @@ For the JWT authenticator (in addition to the Token authenticator fields):
   refreshAccessTokens: true,
   serverTokenRefreshEndpoint: '/api/token-refresh/',
   tokenExpireName: 'exp',
-  refreshLeeway: 0,
-  timeFactor: 1  // example - set to "1000" to convert incoming seconds to milliseconds.
+  refreshLeeway: 0
 ```
 
 [build-status-image]: https://travis-ci.org/jpadilla/ember-simple-auth-token.svg?branch=master

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -125,7 +125,7 @@ export default TokenAuthenticator.extend({
       }
 
       if (expiresAt > now) {
-        const wait = expiresAt - now - (this.refreshLeeway * 1000);
+        const wait = (expiresAt - now - this.refreshLeeway) * 1000;
 
         if (wait > 0) {
           if (this.refreshAccessTokens) {
@@ -197,7 +197,7 @@ export default TokenAuthenticator.extend({
       expiresAt = this.resolveTime(expiresAt);
 
       const now = this.getCurrentTime();
-      const wait = expiresAt - now - (this.refreshLeeway * 1000);
+      const wait = (expiresAt - now - this.refreshLeeway) * 1000;
 
       if (!Ember.isEmpty(token) && !Ember.isEmpty(expiresAt) && wait > 0) {
         Ember.run.cancel(this._refreshTokenTimeout);

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -59,14 +59,6 @@ export default TokenAuthenticator.extend({
   tokenExpireName: 'exp',
 
   /**
-    Default time unit.
-    @property timeFactor
-    @type Integer
-    @default 1 (seconds)
-  */
-  timeFactor: 1,
-
-  /**
     @method init
     @private
   */
@@ -79,7 +71,6 @@ export default TokenAuthenticator.extend({
     this.refreshAccessTokens = Configuration.refreshAccessTokens;
     this.refreshLeeway = Configuration.refreshLeeway;
     this.tokenExpireName = Configuration.tokenExpireName;
-    this.timeFactor = Configuration.timeFactor;
     this.headers = Configuration.headers;
   },
 
@@ -107,7 +98,7 @@ export default TokenAuthenticator.extend({
     return new Ember.RSVP.Promise((resolve, reject) => {
       const now = this.getCurrentTime();
       const token = dataObject.get(this.tokenPropertyName);
-      let expiresAt = this.resolveTime(dataObject.get(this.tokenExpireName));
+      let expiresAt = dataObject.get(this.tokenExpireName);
 
       if (Ember.isEmpty(token)) {
         return reject(new Error('empty token'));
@@ -118,7 +109,7 @@ export default TokenAuthenticator.extend({
         // wasn't included in the data object that was passed in.
         const tokenData = this.getTokenData(token);
 
-        expiresAt = this.resolveTime(tokenData[this.tokenExpireName]);
+        expiresAt = tokenData[this.tokenExpireName];
         if (Ember.isEmpty(expiresAt)) {
           return resolve(data);
         }
@@ -194,7 +185,6 @@ export default TokenAuthenticator.extend({
   */
   scheduleAccessTokenRefresh(expiresAt, token) {
     if (this.refreshAccessTokens) {
-      expiresAt = this.resolveTime(expiresAt);
 
       const now = this.getCurrentTime();
       const wait = (expiresAt - now - this.refreshLeeway) * 1000;
@@ -338,19 +328,6 @@ export default TokenAuthenticator.extend({
   */
   getCurrentTime() {
     return Math.floor((new Date()).getTime() / 1000);
-  },
-
-  /**
-    Handles converting between time units for data between different systems.
-    Default: seconds(1)
-    @method resolveTime
-    @private
-  */
-  resolveTime(time) {
-    if (Ember.isEmpty(time)) {
-      return time;
-    }
-    return new Date(time * this.timeFactor).getTime();
   },
 
   /**

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -11,7 +11,6 @@ var defaults = {
   tokenExpireName: 'exp',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
-  timeFactor: 1,
   headers: {}
 };
 
@@ -114,14 +113,6 @@ export default {
     @default 'exp'
   */
   tokenExpireName: defaults.tokenExpireName,
-
-  /**
-    Default time unit.
-    @property timeFactor
-    @type Integer
-    @default 1 (seconds)
-  */
-  timeFactor: 1,
 
   /**
     The prefix used in the value of the Authorization header.

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -24,7 +24,6 @@
   ENV['ember-simple-auth-token'] = {
     serverTokenEndpoint: '/api/token-auth/',
     serverTokenRefreshEndpoint: '/api/token-refresh/',
-    timeFactor: 1000,
     refreshLeeway: 5
   };
 </pre>
@@ -34,4 +33,3 @@
 
 <p>Token Contents:</p>
 <pre>{{tokenData}}</pre>
-

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -38,7 +38,6 @@ module.exports = function(environment) {
     ENV['ember-simple-auth-token'] = {
       serverTokenEndpoint: '/api/token-auth/',
       serverTokenRefreshEndpoint: '/api/token-refresh/',
-      timeFactor: 1000,
       refreshLeeway: 5
     };
   }
@@ -68,7 +67,6 @@ module.exports = function(environment) {
     ENV['ember-simple-auth-token'] = {
       serverTokenEndpoint: ENV.API_URL + '/api/token-auth/',
       serverTokenRefreshEndpoint: ENV.API_URL + '/api/token-refresh/',
-      timeFactor: 1000,
       refreshLeeway: 5
     };
   }

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -64,14 +64,6 @@ test('assigns tokenExpireName from the configuration object', assert => {
   Configuration.load({}, {});
 });
 
-test('assigns timeFactor from the configuration object', assert => {
-  Configuration.timeFactor = 'timeFactor';
-
-  assert.equal(JWT.create().timeFactor, 'timeFactor');
-
-  Configuration.load({}, {});
-});
-
 test('#restore resolves when the data includes `token` and `expiresAt`', assert => {
   assert.expect(1);
 

--- a/tests/unit/configuration.js
+++ b/tests/unit/configuration.js
@@ -49,7 +49,3 @@ test('refreshLeeway', assert => {
 test('tokenExpireName', assert => {
   assert.equal(Configuration.tokenExpireName, 'exp', 'defaults to "exp"');
 });
-
-test('timeFactor', assert => {
-  assert.equal(Configuration.timeFactor, 1, 'defaults to 1');
-});


### PR DESCRIPTION
Expiration calculation is now only allowed in seconds, adhering to the
jwt spec.