### PR TITLE
Update refresh strategy to use a separate refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ ENV['ember-simple-auth-token'] = {
   identificationField: 'username',
   passwordField: 'password',
   tokenPropertyName: 'token',
+  refreshTokenPropertyName: 'refresh_token',
   authorizationPrefix: 'Bearer ',
   authorizationHeaderName: 'Authorization',
   headers: {},
@@ -194,6 +195,14 @@ For the JWT authenticator (in addition to the Token authenticator fields):
   tokenExpireName: 'exp',
   refreshLeeway: 0
 ```
+
+Since version 3.0 we are supporting refresh tokens.
+If your token implementation manages your *access token* and *refresh token* separately you can specify the property names under `tokenPropertyName` and `refreshTokenPropertyName` on your `ember-simple-auth-token` JSON.
+If your token implementation checks the authorization directly against your access token and you need to refresh it you can specify the token name on `refreshTokenPropertyName`.
+
+For more information:
+[Refresh tokens what are they and when to use them]: https://auth0.com/blog/refresh-tokens-what-are-they-and-when-to-use-them/
+
 
 [build-status-image]: https://travis-ci.org/jpadilla/ember-simple-auth-token.svg?branch=master
 [travis]: https://travis-ci.org/jpadilla/ember-simple-auth-token

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ If your token implementation manages your *access token* and *refresh token* sep
 If your token implementation checks the authorization directly against your access token and you need to refresh it you can specify the token name on `refreshTokenPropertyName`.
 
 For more information:
-[Refresh tokens what are they and when to use them]: https://auth0.com/blog/refresh-tokens-what-are-they-and-when-to-use-them/
+[Refresh tokens what are they and when to use them](https://auth0.com/blog/refresh-tokens-what-are-they-and-when-to-use-them/)
 
 
 [build-status-image]: https://travis-ci.org/jpadilla/ember-simple-auth-token.svg?branch=master

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -131,7 +131,14 @@ export default TokenAuthenticator.extend({
           reject(new Error('unable to refresh token'));
         }
       } else {
-        reject(new Error('token is expired'));
+        // the refresh token might not be expired,
+        // we can't test this on the client so attempt to refresh the token.
+        // If the server rejects the token the user session will be invalidated
+        if (this.refreshAccessTokens) {
+          resolve(this.refreshAccessToken(refreshToken));
+        } else {
+          reject(new Error('token is expired'));
+        }
       }
     });
   },

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -6,6 +6,7 @@ var defaults = {
   identificationField: 'username',
   passwordField: 'password',
   tokenPropertyName: 'token',
+  refreshTokenPropertyName: 'refresh_token',
   refreshAccessTokens: true,
   refreshLeeway: 0,
   tokenExpireName: 'exp',
@@ -88,6 +89,18 @@ export default {
     @default 'token'
   */
   tokenPropertyName: defaults.tokenPropertyName,
+
+  /**
+    The name of the property in session that contains token
+    used for refresh.
+
+    @property refreshTokenPropertyName
+    @readOnly
+    @static
+    @type String
+    @default 'refresh_token'
+  */
+  refreshTokenPropertyName: defaults.refreshTokenPropertyName,
 
   /**
     Sets whether the authenticator automatically refreshes access tokens.

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,6 +22,7 @@
 <p>Settings</p>
 <pre>
   ENV['ember-simple-auth-token'] = {
+    refreshTokenPropertyName: 'token',
     serverTokenEndpoint: '/api/token-auth/',
     serverTokenRefreshEndpoint: '/api/token-refresh/',
     refreshLeeway: 5

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function(environment) {
     };
 
     ENV['ember-simple-auth-token'] = {
-      'refreshTokenPropertyName': 'token',
+      refreshTokenPropertyName: 'token',
       serverTokenEndpoint: '/api/token-auth/',
       serverTokenRefreshEndpoint: '/api/token-refresh/',
       refreshLeeway: 5

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -36,6 +36,7 @@ module.exports = function(environment) {
     };
 
     ENV['ember-simple-auth-token'] = {
+      'refreshTokenPropertyName': 'token',
       serverTokenEndpoint: '/api/token-auth/',
       serverTokenRefreshEndpoint: '/api/token-refresh/',
       refreshLeeway: 5

--- a/tests/unit/authenticators/jwt-test.js
+++ b/tests/unit/authenticators/jwt-test.js
@@ -12,6 +12,10 @@ const createFakeToken = obj => {
   return 'a.' + token + '.b';
 };
 
+const createFakeRefreshToken = () => {
+  return window.btoa('91df47a8-8c7f-4411-98e7-43bfd32df5c4');
+};
+
 const getConvertedTime = time => {
   return time * 1000;
 };
@@ -79,6 +83,8 @@ test('#restore resolves when the data includes `token` and `expiresAt`', assert 
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenPropertyName] = token;
   data[jwt.tokenExpireName] = expiresAt;
@@ -87,7 +93,7 @@ test('#restore resolves when the data includes `token` and `expiresAt`', assert 
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
@@ -115,6 +121,8 @@ test('#restore resolves when the data includes `token` and excludes `expiresAt`'
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenPropertyName] = token;
   data[jwt.tokenExpireName] = expiresAt;
@@ -123,7 +131,7 @@ test('#restore resolves when the data includes `token` and excludes `expiresAt`'
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
@@ -146,6 +154,8 @@ test('#restore rejects when `refreshAccessTokens` is false and token is expired'
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenPropertyName] = token;
   data[jwt.tokenExpireName] = expiresAt;
@@ -156,7 +166,7 @@ test('#restore rejects when `refreshAccessTokens` is false and token is expired'
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
@@ -217,6 +227,8 @@ test('#restore rejects when `token` is excluded.', assert => {
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenExpireName] = expiresAt;
 
@@ -224,7 +236,7 @@ test('#restore rejects when `token` is excluded.', assert => {
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
@@ -252,6 +264,8 @@ test('#restore resolves when `expiresAt` is greater than `now`', assert => {
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenPropertyName] = token;
   data[jwt.tokenExpireName] = expiresAt;
@@ -262,7 +276,7 @@ test('#restore resolves when `expiresAt` is greater than `now`', assert => {
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
@@ -291,8 +305,11 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', a
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenPropertyName] = token;
+  data[jwt.refreshTokenPropertyName] = refreshToken;
   data[jwt.tokenExpireName] = expiresAt;
 
   const refreshedToken = {};
@@ -305,7 +322,7 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', a
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '" }'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
@@ -313,7 +330,7 @@ test('#restore schedules a token refresh when `refreshAccessTokens` is true.', a
       // Check that Ember.run.later ran.
       var spyCall = Ember.run.later.getCall(0);
       assert.deepEqual(spyCall.args[1], App.authenticator.refreshAccessToken);
-      assert.deepEqual(spyCall.args[2], token);
+      assert.deepEqual(spyCall.args[2], refreshToken);
 
       App.authenticator.refreshAccessToken.restore();
     });
@@ -432,8 +449,11 @@ test('#restore schedule access token refresh and refreshes it when time is appro
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const data = {};
   data[jwt.tokenPropertyName] = token;
+  data[jwt.refreshTokenPropertyName] = refreshToken;
   data[jwt.tokenExpireName] = expiresAt;
 
   // Set the refreshLeeway to > expiresAt.
@@ -460,12 +480,12 @@ test('#restore schedule access token refresh and refreshes it when time is appro
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '" }'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
     refreshAccessToken.call(refreshAccessTokenTarget, refreshAccessTokenArgs).then(response => {
-      assert.deepEqual(response, { exp: expiresAt, token: token });
+      assert.deepEqual(response, { exp: expiresAt, token: token, 'refresh_token': refreshToken });
     });
   });
 });
@@ -533,6 +553,8 @@ test('#authenticate schedules a token refresh when `refreshAccessTokens` is true
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const credentials = {
     identification: 'username',
     password: 'password'
@@ -542,14 +564,14 @@ test('#authenticate schedules a token refresh when `refreshAccessTokens` is true
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   Ember.run(() => {
     App.authenticator.authenticate(credentials).then(() => {
       var spyCall = Ember.run.later.getCall(0);
       assert.deepEqual(spyCall.args[1], App.authenticator.refreshAccessToken);
-      assert.deepEqual(spyCall.args[2], token);
+      assert.deepEqual(spyCall.args[2], refreshToken);
     });
   });
 });
@@ -566,6 +588,8 @@ test('#authenticate does not schedule a token refresh when `refreshAccessTokens`
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   const credentials = {
     identification: 'username',
     password: 'password'
@@ -575,7 +599,7 @@ test('#authenticate does not schedule a token refresh when `refreshAccessTokens`
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   App.authenticator.refreshAccessTokens = false;
@@ -630,11 +654,7 @@ test('#refreshAccessToken makes an AJAX request to the token endpoint.', assert 
   const jwt = JWT.create(),
     expiresAt = 3;
 
-  let token = {};
-  token[jwt.identificationField] = 'test@test.com';
-  token[jwt.tokenExpireName] = expiresAt;
-
-  token = createFakeToken(token);
+  let token = createFakeRefreshToken();
 
   App.authenticator.refreshAccessToken(token);
 
@@ -644,7 +664,7 @@ test('#refreshAccessToken makes an AJAX request to the token endpoint.', assert 
     assert.deepEqual(args, {
       url: jwt.serverTokenRefreshEndpoint,
       method: 'POST',
-      data: JSON.stringify({ token: token }),
+      data: JSON.stringify({ refresh_token: token }),
       dataType: 'json',
       contentType: 'application/json',
       headers: {}
@@ -652,22 +672,17 @@ test('#refreshAccessToken makes an AJAX request to the token endpoint.', assert 
   });
 });
 
-test('#refreshAccessToken makes an AJAX request to the token endpoint with nested tokenPropertyName.', assert => {
+test('#refreshAccessToken makes an AJAX request to the token endpoint with nested refreshTokenPropertyName.', assert => {
   assert.expect(1);
   const jwt = JWT.create();
   const expiresAt = 3;
 
-  let token = {};
-  token[jwt.identificationField] = 'test@test.com';
-  token[jwt.tokenExpireName] = expiresAt;
+  let token = createFakeRefreshToken();
 
-  token = createFakeToken(token);
+  let refreshTokenPropertyNameWas = App.authenticator.refreshTokenPropertyName;
 
-  let authenticator = App.authenticator;
-  let tokenPropertyNameWas = authenticator.tokenPropertyName;
-
-  authenticator.tokenPropertyName = 'auth.nested.token';
-  authenticator.refreshAccessToken(token);
+  App.authenticator.refreshTokenPropertyName = 'auth.nested.token';
+  App.authenticator.refreshAccessToken(token);
 
   Ember.run(() => {
     var args = Ember.$.ajax.getCall(0).args[0];
@@ -698,11 +713,13 @@ test('#refreshAccessToken triggers the `sessionDataUpdated` event on successful 
 
   token = createFakeToken(token);
 
+  let refreshToken = createFakeRefreshToken();
+
   App.server.respondWith('POST', jwt.serverTokenRefreshEndpoint, [
     201, {
       'Content-Type': 'application/json'
     },
-    '{ "token": "' + token + '"}'
+    '{ "token": "' + token + '", "refresh_token": "' + refreshToken + '" }'
   ]);
 
   App.authenticator.refreshAccessToken(token);

--- a/tests/unit/configuration.js
+++ b/tests/unit/configuration.js
@@ -26,6 +26,10 @@ test('tokenPropertyName', assert => {
   assert.equal(Configuration.tokenPropertyName, 'token', 'defaults to "token"');
 });
 
+test('refreshTokenPropertyName', assert => {
+  assert.equal(Configuration.refreshTokenPropertyName, 'refresh_token', 'defaults to "refresh_token"');
+});
+
 test('authorizationPrefix', assert => {
   assert.equal(Configuration.authorizationPrefix, 'Bearer ', 'defaults to "Bearer "');
 });


### PR DESCRIPTION
As discussed in this issue #162 I've made the library use a separate token to refresh the JWT.

I've updated the tests and they all pass but someone should really check what I've done, testing is not my strong point.

I've ran this on my app and confirmed it refreshes the token as expected.