### PR TITLE
Add TokenAuthorizerMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
 ```
 *DataAdapterMixin is supported for Ember 1.13 and above*
 
+### Deprecation in ember-simple-auth 2.0
+
+Ember Simple Auth has deprecated the use of Authorizers. The alternative is to use the `TokenAuthorizerMixin`.
+
+```js
+// app/adapters/application.js
+import DS from 'ember-data';
+import TokenAuthorizerMixin from 'ember-simple-auth-token/mixins/token-authorizer';
+
+export default DS.JSONAPIAdapter.extend(TokenAuthorizerMixin);
+```
+
 ## Available Customization Options
 
 For the Token authenticator:

--- a/addon/mixins/token-authorizer.js
+++ b/addon/mixins/token-authorizer.js
@@ -1,0 +1,86 @@
+import Ember from 'ember';
+import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
+import Configuration from '../configuration';
+
+/**
+  Authorizer Mixin that works with token-based authentication like JWT
+  by sending the `token` properties from the session in the `Authorization` header.
+
+  @class TokenAuthorizer
+  @module ember-simple-auth-token/mixins/token-authorizer
+  @extends Ember.Mixin
+*/
+export default Ember.Mixin.create(DataAdapterMixin, {
+  session: Ember.inject.service('session'),
+
+  /**
+    The prefix used in the value of the Authorization header.
+
+    This value can be configured via
+    [`SimpleAuth.Configuration.Token#authorizationPrefix`](#SimpleAuth-Configuration-Token-authorizationPrefix).
+
+    @property authorizationPrefix
+    @type String
+    @default 'Bearer '
+  */
+  authorizationPrefix: 'Bearer ',
+
+  /**
+    The name of the property in session that contains token used for authorization.
+
+    This value can be configured via
+    [`SimpleAuth.Configuration.Token#tokenPropertyName`](#SimpleAuth-Configuration-Token-tokenPropertyName).
+
+    @property tokenPropertyName
+    @type String
+    @default 'token'
+  */
+  tokenPropertyName: 'token',
+
+  /**
+    The name of the HTTP Header used to send token.
+
+    This value can be configured via
+    [`SimpleAuth.Configuration.Token#authorizationHeaderName`](#SimpleAuth-Configuration-Token-authorizationHeaderName).
+
+    @property authorizationHeaderName
+    @type String
+    @default 'Authorization'
+  */
+  authorizationHeaderName: 'Authorization',
+
+  /**
+    @method init
+    @private
+  */
+  init() {
+    this._super(...arguments);
+    this.tokenPropertyName = Configuration.tokenPropertyName;
+    this.authorizationHeaderName = Configuration.authorizationHeaderName;
+
+    if (Configuration.authorizationPrefix || Configuration.authorizationPrefix === null) {
+      this.authorizationPrefix = Configuration.authorizationPrefix;
+    }
+  },
+
+  /**
+    Authorizes an XHR request by sending the `token`
+    properties from the session in the `Authorization` header:
+
+    ```
+    Authorization: Bearer <token>
+    ```
+
+    @method authorize
+    @param {XMLHttpRequest} xhr
+  */
+  authorize(xhr) {
+    const data = Ember.get(this, 'session.data.authenticated');
+    const token = Ember.get(data, this.tokenPropertyName);
+    const prefix = this.authorizationPrefix ? this.authorizationPrefix : '';
+
+    if (this.get('session.isAuthenticated') && !Ember.isEmpty(token)) {
+      xhr.setRequestHeader(this.authorizationHeaderName, prefix + token);
+    }
+  }
+});


### PR DESCRIPTION
This fixes issue #218

All options are the same as the old authorizer but uses the new syntax. The Mixin will import DataAdapterMixin and session for you.

I was unsure on tests so would appreciate anyone pushing a commit or two to help with that.

Added a blurb to the README but it could use some help from someone more articulate then I.