### PR TITLE
move ember-get-config to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-auth-token",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1510,7 +1510,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz",
       "integrity": "sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==",
-      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.1.0",
         "mkdirp": "^0.5.1"
@@ -3894,7 +3893,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
       "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
-      "dev": true,
       "requires": {
         "broccoli-file-creator": "^1.1.1",
         "ember-cli-babel": "^6.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-auth-token",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "An authenticator and authorizer for Ember Simple Auth that is compatible with token-based authentication like JWT in Ember CLI applications.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "ember-get-config": "^0.2.4"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",
@@ -49,7 +50,6 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^4.0.1",
-    "ember-get-config": "^0.2.4",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",


### PR DESCRIPTION
Without this package in production dependencies I am getting errors about importing ember-get-config.