### PR TITLE
User base64 instead of atob for fastboot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Ember Simple Auth Token can be installed with [Ember CLI][ember-cli] by running:
 ember install ember-simple-auth-token
 ```
 
+If using FastBoot and the JWT authenticator, `buffer` must be added to your `fastbootDependencies`.
+
 ## Setup
 
 ### Authenticator

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -162,7 +162,7 @@ export default TokenAuthenticator.extend({
           delete this._refreshTokenTimeout;
           this._refreshTokenTimeout = later(this, this.refreshAccessToken, refreshToken, wait);
         } else if (expiresAt > now) {
-          throw new Error('refreshLeeway is too large which is preventing token refresh');
+          throw new Error('refreshLeeway is too large which is preventing token refresh.');
         }
       }
     }

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -9,7 +9,6 @@ import TokenAuthenticator from './token';
 import config from 'ember-get-config';
 
 const decode = str => {
-  console.log(str);
   return atob ? atob(str) : Buffer.from(str, 'base64').toString('utf-8');
 };
 

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* global FastBoot */
 
 import EmberObject, { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
@@ -10,9 +10,15 @@ import config from 'ember-get-config';
 
 const decode = str => {
   try {
-    return atob ? atob(str) : Buffer.from(str, 'base64').toString('utf-8');
+    if (typeof atob === 'function') {
+      return atob(str);
+    } else if (typeof FastBoot === 'object') {
+      return FastBoot.require('buffer').Buffer.from(str, 'base64').toString('utf-8');
+    } else {
+      throw new Error();
+    }
   } catch (err) {
-    throw new Error('atob or Buffer must be available for JWT parsing. If you are using FastBoot, make sure buffer is added to your fastbootDependencies.');
+    throw new Error('atob or buffer must be available for JWT parsing. If you are using FastBoot, make sure buffer is added to your fastbootDependencies.');
   }
 };
 

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -1,3 +1,5 @@
+/* global Buffer */
+
 import EmberObject, { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { Promise, resolve } from 'rsvp';
@@ -5,6 +7,11 @@ import { isEmpty } from '@ember/utils';
 import { cancel, later } from '@ember/runloop';
 import TokenAuthenticator from './token';
 import config from 'ember-get-config';
+
+const decode = str => {
+  console.log(str);
+  return atob ? atob(str) : Buffer.from(str, 'base64').toString('utf-8');
+};
 
 /**
   JWT (JSON Web Token) Authenticator that supports automatic token refresh.
@@ -218,7 +225,7 @@ export default TokenAuthenticator.extend({
   */
   getTokenData(token) {
     const payload = token.split('.')[1];
-    const decodedPayload = window.base64.decode(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    const decodedPayload = decode(payload.replace(/-/g, '+').replace(/_/g, '/'));
     const tokenData = decodeURIComponent(window.escape(decodedPayload));
 
     try {

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -218,7 +218,8 @@ export default TokenAuthenticator.extend({
   */
   getTokenData(token) {
     const payload = token.split('.')[1];
-    const tokenData = decodeURIComponent(window.escape(atob(payload.replace (/-/g, '+').replace(/_/g, '/'))));
+    const decodedPayload = window.base64.decode(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    const tokenData = decodeURIComponent(window.escape(decodedPayload));
 
     try {
       return JSON.parse(tokenData);

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -1,4 +1,4 @@
-/* global require */
+/* global Buffer */
 
 import EmberObject, { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
@@ -10,9 +10,9 @@ import config from 'ember-get-config';
 
 const decode = str => {
   try {
-    return atob ? atob(str) : require('buffer').Buffer.from(str, 'base64').toString('utf-8');
+    return atob ? atob(str) : Buffer.from(str, 'base64').toString('utf-8');
   } catch (err) {
-    throw new Error('atob or buffer must be available for JWT parsing. If you are using FastBoot, make sure buffer is added to your fastbootDependencies.');
+    throw new Error('atob or Buffer must be available for JWT parsing. If you are using FastBoot, make sure buffer is added to your fastbootDependencies.');
   }
 };
 

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -9,16 +9,17 @@ import TokenAuthenticator from './token';
 import config from 'ember-get-config';
 
 const decode = str => {
-  try {
-    if (typeof atob === 'function') {
-      return atob(str);
-    } else if (typeof FastBoot === 'object') {
-      return FastBoot.require('buffer').Buffer.from(str, 'base64').toString('utf-8');
-    } else {
-      throw new Error();
+  if (typeof atob === 'function') {
+    return atob(str);
+  } else if (typeof FastBoot === 'object') {
+    try {
+      const buffer = FastBoot.require('buffer');
+      return buffer.Buffer.from(str, 'base64').toString('utf-8');
+    } catch (err) {
+      throw new Error('buffer must be available for decoding base64 strings in FastBoot. Make sure to add buffer to your fastbootDependencies.');
     }
-  } catch (err) {
-    throw new Error('atob or buffer must be available for JWT parsing. If you are using FastBoot, make sure buffer is added to your fastbootDependencies.');
+  } else {
+    throw new Error('Neither atob nor the FastBoot global are avaialble. Unable to decode base64 strings.');
   }
 };
 

--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/* global require */
 
 import EmberObject, { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
@@ -9,7 +9,11 @@ import TokenAuthenticator from './token';
 import config from 'ember-get-config';
 
 const decode = str => {
-  return atob ? atob(str) : Buffer.from(str, 'base64').toString('utf-8');
+  try {
+    return atob ? atob(str) : require('buffer').Buffer.from(str, 'base64').toString('utf-8');
+  } catch (err) {
+    throw new Error('atob or buffer must be available for JWT parsing. If you are using FastBoot, make sure buffer is added to your fastbootDependencies.');
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/jpadilla/ember-simple-auth-token/issues/247

`window.base64` from https://github.com/simplabs/ember-simple-auth/blob/master/addon/authenticators/oauth2-password-grant.js#L122