### PR TITLE
Bump ember fetch version, fixes #255

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
     "ember-get-config": "^0.2.4",
-    "ember-fetch": "^4.0.0 || ^5.0.0",
+    "ember-fetch": "^4.0.0 || ^5.0.0 || ^6.0.0",
     "ember-simple-auth": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The ember-fetch dependency just needs to be bumped to also allow v6.

Testing:
In your `package.json`, change `ember-simple-auth-token` to be:
```
    "ember-simple-auth-token": "joshuataylor/ember-simple-auth-token#bump-ember-fetch",
```

Now rerun yarn, and you should be good to test.