### PR TITLE
Use pre-calulated value for expiresAt on restore

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -96,7 +96,7 @@ export default TokenAuthenticator.extend({
 
         if (wait > 0) {
           if (this.refreshAccessTokens) {
-            this.scheduleAccessTokenRefresh(dataObject.get(this.tokenExpireName), refreshToken);
+            this.scheduleAccessTokenRefresh(expiresAt, refreshToken);
           }
           return resolve(data);
         } else if (this.refreshAccessTokens) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-auth-token",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-auth-token",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "An authenticator and authorizer for Ember Simple Auth that is compatible with token-based authentication like JWT in Ember CLI applications.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
The expiresAt variable was undefined when passing into the scheduleAccessTokenRefresh, however it is pre-calculated further up in the function. This is to use the pre-calculated value instead of assuming that value is the data object.