### PR TITLE
Remove use of assign polyfill

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -2,7 +2,6 @@
 
 import EmberObject, { get } from '@ember/object';
 import { getOwner } from '@ember/application';
-import { assign } from '@ember/polyfills';
 import { Promise, resolve } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { cancel, later } from '@ember/runloop';
@@ -134,7 +133,7 @@ export default TokenAuthenticator.extend({
     @return {Promise} Promise that resolves when an auth token is successfully acquired from the server and rejects otherwise
   */
   authenticate(credentials, headers) {
-    return this.makeRequest(this.serverTokenEndpoint, credentials, assign({}, this.headers, headers)).then(response => {
+    return this.makeRequest(this.serverTokenEndpoint, credentials, {...this.headers, ...headers}).then(response => {
       return this.handleAuthResponse(response.json);
     });
   },
@@ -293,7 +292,7 @@ export default TokenAuthenticator.extend({
       this.scheduleAccessTokenRefresh(expiresAt, refreshToken);
     }
 
-    return assign(response, tokenExpireData, {tokenData: tokenData});
+    return {...response, ...tokenExpireData, tokenData: tokenData};
   },
 
   /**

--- a/addon/authenticators/token.js
+++ b/addon/authenticators/token.js
@@ -1,7 +1,6 @@
 import EmberObject from '@ember/object';
 import { getOwner } from '@ember/application';
 import fetch from 'fetch';
-import { assign } from '@ember/polyfills';
 import { Promise, reject, resolve } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import Base from 'ember-simple-auth/authenticators/base';
@@ -58,7 +57,7 @@ export default Base.extend({
     @return {Promise} Promise that resolves when an auth token is successfully acquired from the server and rejects otherwise
   */
   authenticate(credentials, headers) {
-    return this.makeRequest(this.serverTokenEndpoint, credentials, assign({}, this.headers, headers)).then(response => {
+    return this.makeRequest(this.serverTokenEndpoint, credentials, {...this.headers, ...headers}).then(response => {
       return response.json;
     });
   },
@@ -83,10 +82,11 @@ export default Base.extend({
   makeRequest(url, data, headers) {
     return fetch(url, {
       method: 'POST',
-      headers: assign({
+      headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      }, headers),
+        'Content-Type': 'application/json',
+        ...headers
+      },
       body: JSON.stringify(data)
     }).then(response => {
       const res = {


### PR DESCRIPTION
This will remove the deprecation warnings about `Ember.assign`. I've used the spread operator.

https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign