### PR TITLE
[BUGFIX] respect tokenDataPropertyName

### DIFF
--- a/addon/src/authenticators/jwt.js
+++ b/addon/src/authenticators/jwt.js
@@ -288,7 +288,7 @@ export default class JwtAuthenticator extends TokenAuthenticator {
       this.scheduleAccessTokenRefresh(expiresAt, refreshToken);
     }
 
-    return {...response, ...tokenExpireData, tokenData: tokenData};
+    return {...response, ...tokenExpireData, [this.tokenDataPropertyName]: tokenData};
   }
 
   /**

--- a/test-app/tests/unit/authenticators/jwt-test.js
+++ b/test-app/tests/unit/authenticators/jwt-test.js
@@ -658,4 +658,26 @@ module('Unit | Authenticator | authenticators/jwt.js', function (hooks) {
     assert.strictEqual(data.data.user.name, 'Thorbjørn Hermansen');
   });
 
+  test('#handleAuthResponse uses custom tokenDataPropertyName', function(assert) {
+    assert.expect(2);
+
+    const customPropertyName = 'customTokenData';
+    this.owner.application.jwt.tokenDataPropertyName = customPropertyName;
+
+    const token = createFakeToken();
+    const refreshToken = createFakeToken();
+    const credentials = createFakeCredentials();
+    const expectedTokenData = this.owner.application.jwt.getTokenData(token);
+
+    this.server.post('/token-auth', () => ({
+      token: token,
+      refresh_token: refreshToken
+    }), 200);
+
+    this.owner.application.jwt.authenticate(credentials).then(data => {
+      assert.ok(data[customPropertyName], 'Session data contains custom property name');
+      assert.deepEqual(data[customPropertyName], expectedTokenData, 'Custom property contains correct token data');
+      clearState(this.owner.application.jwt);
+    });
+  });
 });


### PR DESCRIPTION
I think an oversight but `tokenDataPropertyName` not used anywhere in the code.